### PR TITLE
[v1.0-fixes] Update configuration during splitting

### DIFF
--- a/util-conf.R
+++ b/util-conf.R
@@ -116,7 +116,6 @@ CodefaceConf = R6::R6Class("CodefaceConf",
         },
 
 
-
         ## construct path to a Codeface configuration
         ## - data: path to codeface-data folder
         ## - selection.process: one of: threemonth, releases
@@ -192,19 +191,12 @@ CodefaceConf = R6::R6Class("CodefaceConf",
             revisions.dates = revisions.df[["date"]]
             if (!is.null(revisions.dates)) names(revisions.dates) = revisions
 
-            ## store revision data
-            conf$revisions = revisions
-            conf$revisions.dates = revisions.dates
-
-            ## call-graph revisions (do a postprocessing for list of revisions)
-            conf$revisions.callgraph = private$postprocess.revision.list.for.callgraph.data(conf$revisions)
-
-            ## compute revision ranges
-            conf$ranges = private$construct.ranges(conf$revisions)
-            conf$ranges.callgraph = private$construct.ranges(conf$revisions.callgraph)
-
             ## SAVE FULL CONFIGURATION OBJECT
             private$conf = conf
+
+            ## construct and save revisions and ranges
+            ## (this has to be done after storing conf due to the needed access to the conf object)
+            self$set.revisions(revisions, revisions.dates)
 
             ## logging
             logging::logdebug("Configuration:\n%s", self$get.conf.as.string())
@@ -345,6 +337,22 @@ CodefaceConf = R6::R6Class("CodefaceConf",
             idx = which(self$get.ranges() == range)
             rev = self$get.revisions.callgraph()[idx + 1]
             return(rev)
+        },
+
+        ## UPDATING CONFIGURATION ENTRIES
+
+        ## set the revisions and ranges
+        set.revisions = function(revisions, revisions.dates) {
+            ## store revision data
+            private$conf$revisions = revisions
+            private$conf$revisions.dates = revisions.dates
+
+            ## call-graph revisions (do a postprocessing for list of revisions)
+            private$conf$revisions.callgraph = private$postprocess.revision.list.for.callgraph.data(private$conf$revisions)
+
+            ## compute revision ranges
+            private$conf$ranges = private$construct.ranges(private$conf$revisions)
+            private$conf$ranges.callgraph = private$construct.ranges(private$conf$revisions.callgraph)
         }
 
     )

--- a/util-split.R
+++ b/util-split.R
@@ -88,6 +88,9 @@ split.data.time.based = function(project.data, time.period = "3 months", bins = 
     data.split = parallel::mclapply(bins.labels, function(bin) lapply(data.split, `[[`, bin))
     names(data.split) = bins.ranges
 
+    ## adapt project configuration
+    project.data$get.conf()$set.revisions(bins, bins.date)
+
     ## construct CodefaceRangeData objects
     logging::logdebug("Constructing CodefaceRangeData objects.")
     cf.data = parallel::mclapply(bins.ranges, function(range) {


### PR DESCRIPTION
When splitting data objects using the split functions, the project
configuration is updated with the revisions, ranges and revision dates
obtained from the splitting data. This way, retrieving the ranges from
any configuraton object gets the right ranges.

Thanks to the object orientation, the original configuration that was
used to construct the to-be-split data object is also updated. This way,
also the original configuration object (when stored in a variable) is
updated.

This is a backport of commit 9f7219f73a86f5cc4a33afa206a122ef07338b3c
for version 1.0.