### PR TITLE
Fix file encoding for reading data files

### DIFF
--- a/util-conf.R
+++ b/util-conf.R
@@ -622,7 +622,7 @@ ProjectConf = R6::R6Class("ProjectConf", inherit = Conf,
             ## read revisions file
             revisions.file = file.path(conf$datapath, "revisions.list")
             revisions.df <- try(read.table(revisions.file, header = FALSE, sep = ";", strip.white = TRUE,
-                                           fileEncoding = "latin1", encoding = "utf8"), silent = TRUE)
+                                           encoding = "UTF-8"), silent = TRUE)
             ## break if the list of revisions is empty or any other error occurs
             if (inherits(revisions.df, 'try-error')) {
                 logging::logerror("There are no revisions available for the current casestudy.")

--- a/util-read.R
+++ b/util-read.R
@@ -31,7 +31,7 @@ read.commits.raw = function(data.path, artifact) {
 
     ## read data.frame from disk (as expected from save.list.to.file) [can be empty]
     commit.data <- try(read.table(file, header = FALSE, sep = ";", strip.white = TRUE,
-                                  fileEncoding = "latin1", encoding = "utf8"), silent = TRUE)
+                                  encoding = "UTF-8"), silent = TRUE)
 
     ## handle the case that the list of commits is empty
     if (inherits(commit.data, 'try-error')) {
@@ -156,7 +156,7 @@ read.mails = function(data.path) {
 
     ## read data.frame from disk (as expected from save.list.to.file) [can be empty]
     mail.data <- try(read.table(file, header = FALSE, sep = ";", strip.white = TRUE,
-                                fileEncoding = "latin1", encoding = "utf8"), silent = TRUE)
+                                encoding = "UTF-8"), silent = TRUE)
 
     ## handle the case that the list of mails is empty
     if (inherits(mail.data, 'try-error')) {
@@ -220,7 +220,7 @@ read.authors = function(data.path) {
 
     ## read data.frame from disk (as expected from save.list.to.file) [can be empty]
     authors.df <- try(read.table(file, header = FALSE, sep = ";", strip.white = TRUE,
-                                 fileEncoding = "latin1", encoding = "utf8"), silent = TRUE)
+                                 encoding = "UTF-8"), silent = TRUE)
 
     ## break if the list of authors is empty
     if (inherits(authors.df, 'try-error')) {
@@ -319,7 +319,7 @@ read.issues = function(data.path) {
 
     ## read issues from disk [can be empty]
     issue.data = try(read.table(filepath, header = FALSE, sep = ";", strip.white = TRUE,
-                                  fileEncoding = "latin1", encoding = "utf8"), silent = TRUE)
+                                encoding = "UTF-8"), silent = TRUE)
 
     ## handle the case that the list of commits is empty
     if (inherits(issue.data, 'try-error')) {


### PR DESCRIPTION
After experiencing encoding problems on both Windows and Ubuntu, the
encoding is now properly set for reading data files from disk. The fix
is to remove the 'fileEncoding' parameter.

Signed-off-by: Claus Hunsen <hunsen@fim.uni-passau.de>
Signed-off-by: Thomas Bock <bockthom@fim.uni-passau.de>
Signed-off-by: Angelika Schmid <angelika.schmid@uni-passau.de>