### PR TITLE
Fix sliding-window creation in various situations & add tests for sliding-window functionality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ The current build status is as follows:
   * Code must be reviewed by one other project member and, if needed, be properly adapted/fixed.
   * We add the `Reviewed-by` tag only for the merge commit.
 
-There will be another checklist for you when you open an actual pull request provided by [the corresponding template](.github/PULL_REQUEST_TEMPLATE/pull-request.md).
+There will be another checklist for you when you open an actual pull request provided by [the corresponding template](.github/PULL_REQUEST_TEMPLATE.md).
 
 ## Style Conventions
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,11 +6,18 @@
 - Add a new file `util-tensor.R` containing the class `FourthOrderTensor` to create (author x relation x author x relation) tensors from a list of networks (with each network having a different relation) and its corresponding utility function `get.author.networks.for.multiple.relations` (PR #173, c136b1f6127d73c25f08ae2f317246747aa9ea2b, e4ee0dc926b22ff75d5fd801c1f131bcff4c22eb, 051a5f0287022f97e2367ed0e9591b9df9dbdb3d)
 - Add function `calculate.EDCPTD.centrality` for calculating the EDCPTD centrality for a fourth-order tensor in the above described form (c136b1f6127d73c25f08ae2f317246747aa9ea2b, e4ee0dc926b22ff75d5fd801c1f131bcff4c22eb, 051a5f0287022f97e2367ed0e9591b9df9dbdb3d)
 - Add new file `util-networks-misc.R` which contains miscellaneous functions for processing network data and creating and converting various kinds of adjacency matrices: `get.author.names.from.networks`, `get.author.names.from.data`, `get.expanded.adjacency`, `get.expanded.adjacency.matrices`, `get.expanded.adjacency.matrices.cumulated`, `convert.adjacency.matrix.list.to.array` (051a5f0287022f97e2367ed0e9591b9df9dbdb3d)
+- Add tests for sliding-window functionality and make parameterized tests possible (a3ad0a81015c7f23bce958d5c1922e3b82b28bda, 2ed84ac55d434f62341297b1aa9676c12e383491, PR #184)
 
 ### Changed/Improved
 - Adjust the function `get.authors.by.data.source`: Rename its single parameter to `data.sources` and change the function so that it can extract the authors for multiple data sources at once. The default value of the parameter is a vector containing all the available data sources (commits, mails, issues) (051a5f0287022f97e2367ed0e9591b9df9dbdb3d)
 - Adjust recommended R version to 3.6.3 in README (92be262514277acb774ab2885c1c0d1c10f03373)
 - Add R version 4.0 to test suite and adjust package installation in `install.R` to improve compatibility with Travis CI (40aa0d80e2a94434a8be75925dbefbde6d3518b2, 1ba036758a63767e2fcef525c98f5a4fd6938c39, #161)
+
+### Fixed
+
+- Fix sliding-window creation in various splitting functions (`split.network.time.based`, `split.networks.time.based`, `split.data.time.based`, `split.data.activity.based`, `split.network.activity.based`) and also fix the computation of overlapping ranges in the function `construct.overlapping.ranges` to make sure that the last and the second-last range do not cover the same range) (1abc1b8dbfc65ccad0cbbc8e33b209e39d2f8118, c34c42aef32a30b82adc53384fd6a1b09fc75dee, 097cebcc477b1b65056d512124575f5a78229c3e, 9a1b6516f490b72b821be2d5365d98cac1907b2f, 0fc179e2735bec37d26a68c6c351ab43770007d2, cad28bf221f942eb25e997aaa2de553181956680, PR #184)
+- Fix off-by-1 error in the function `get.data.cut.to.same.date` (f0744c0e14543292cccb1aa9a61f822755ee7183)
+- Fix missing or wrongly set layout when plotting networks (#186, 720cc7ba7bdb635129c7669911aef8e7c6200a6b)
 
 
 ## 3.6

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,10 +14,9 @@
 - Add R version 4.0 to test suite and adjust package installation in `install.R` to improve compatibility with Travis CI (40aa0d80e2a94434a8be75925dbefbde6d3518b2, 1ba036758a63767e2fcef525c98f5a4fd6938c39, #161)
 
 ### Fixed
-
-- Fix sliding-window creation in various splitting functions (`split.network.time.based`, `split.networks.time.based`, `split.data.time.based`, `split.data.activity.based`, `split.network.activity.based`) and also fix the computation of overlapping ranges in the function `construct.overlapping.ranges` to make sure that the last and the second-last range do not cover the same range) (1abc1b8dbfc65ccad0cbbc8e33b209e39d2f8118, c34c42aef32a30b82adc53384fd6a1b09fc75dee, 097cebcc477b1b65056d512124575f5a78229c3e, 9a1b6516f490b72b821be2d5365d98cac1907b2f, 0fc179e2735bec37d26a68c6c351ab43770007d2, cad28bf221f942eb25e997aaa2de553181956680, PR #184)
+- Fix sliding-window creation in various splitting functions (`split.network.time.based`, `split.networks.time.based`, `split.data.time.based`, `split.data.activity.based`, `split.network.activity.based`) and also fix the computation of overlapping ranges in the function `construct.overlapping.ranges` to make sure that the last and the second-last range do not cover the same range) (1abc1b8dbfc65ccad0cbbc8e33b209e39d2f8118, c34c42aef32a30b82adc53384fd6a1b09fc75dee, 097cebcc477b1b65056d512124575f5a78229c3e, 9a1b6516f490b72b821be2d5365d98cac1907b2f, 0fc179e2735bec37d26a68c6c351ab43770007d2, cad28bf221f942eb25e997aaa2de553181956680, 7602af2cf46f699b2285d53819dec614c71754c6, PR #184)
 - Fix off-by-1 error in the function `get.data.cut.to.same.date` (f0744c0e14543292cccb1aa9a61f822755ee7183)
-- Fix missing or wrongly set layout when plotting networks (#186, 720cc7ba7bdb635129c7669911aef8e7c6200a6b)
+- Fix missing or wrongly set layout when plotting networks (#186, 720cc7ba7bdb635129c7669911aef8e7c6200a6b, 877931b94f87ca097c2f8f3c55e4b4bcc6087742)
 
 
 ## 3.6

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Alternatively, you can run `Rscript install.R` to install the packages.
 - `logging`: Logging
 - `sqldf`: For advanced aggregation of `data.frame` objects
 - `testthat`: For the test suite
+- `patrick`: For the test suite
 - `ggplot2`: For plotting of data
 - `ggraph`: For plotting of networks (needs `udunits2` system library, e.g., `libudunits2-dev` on Ubuntu!)
 - `markovchain`: For core/peripheral transition probabilities

--- a/install.R
+++ b/install.R
@@ -33,6 +33,7 @@ packages = c(
     "logging",
     "sqldf",
     "testthat",
+    "patrick",
     "ggplot2",
     "ggraph",
     "markovchain",

--- a/tests.R
+++ b/tests.R
@@ -12,6 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2017, 2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /

--- a/tests.R
+++ b/tests.R
@@ -42,8 +42,9 @@ sessionInfo()
 
 logging::loginfo("Running test suite.")
 
-## load package 'testthat'
+## load packages 'testthat' and 'patrick'
 requireNamespace("testthat")
+requireNamespace("patrick")
 
 ## starting tests
 do.tests = function(dir) {

--- a/tests/test-data-cut.R
+++ b/tests/test-data-cut.R
@@ -16,6 +16,7 @@
 ## Copyright 2018 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 ## Copyright 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## All Rights Reserved.
 
@@ -62,14 +63,14 @@ test_that("Cut commit and mail data to same date range.", {
                                       artifact.type = c("Feature", "Feature"),
                                       artifact.diff.size = as.integer(c(1, 1)))
 
-    mail.data.expected = data.frame(author.name = c("Thomas"),
-                                    author.email = c("thomas@example.org"),
-                                    message.id = c("<65a1sf31sagd684dfv31@mail.gmail.com>"),
-                                    date = get.date.from.string("2016-07-12 16:04:40"),
-                                    date.offset = as.integer(c(100)),
-                                    subject = c("Re: Fw: busybox 2 tab"),
-                                    thread = sprintf("<thread-%s>", c(9)),
-                                    artifact.type = "Mail")
+    mail.data.expected = data.frame(author.name = c("Thomas", "Olaf"),
+                                    author.email = c("thomas@example.org", "olaf@example.org"),
+                                    message.id = c("<65a1sf31sagd684dfv31@mail.gmail.com>", "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>"),
+                                    date = get.date.from.string(c("2016-07-12 16:04:40", "2016-07-12 16:05:37")),
+                                    date.offset = as.integer(c(100, 200)),
+                                    subject = c("Re: Fw: busybox 2 tab", "Re: Fw: busybox 10"),
+                                    thread = sprintf("<thread-%s>", c(9, 9)),
+                                    artifact.type = c("Mail", "Mail"))
 
     commit.data = x.data$get.data.cut.to.same.date(data.sources = data.sources)$get.commits()
     rownames(commit.data) = 1:nrow(commit.data)

--- a/tests/test-networks-cut.R
+++ b/tests/test-networks-cut.R
@@ -14,6 +14,7 @@
 ## Copyright 2017 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2018 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## All Rights Reserved.
 
@@ -62,14 +63,14 @@ test_that("Cut commit and mail data to same date range.", {
                                       artifact.type = c("Feature", "Feature"),
                                       artifact.diff.size = as.integer(c(1, 1)))
 
-    mail.data.expected = data.frame(author.name = c("Thomas"),
-                                    author.email = c("thomas@example.org"),
-                                    message.id = c("<65a1sf31sagd684dfv31@mail.gmail.com>"),
-                                    date = get.date.from.string(c("2016-07-12 16:04:40")),
-                                    date.offset = as.integer(c(100)),
-                                    subject = c("Re: Fw: busybox 2 tab"),
-                                    thread = sprintf("<thread-%s>", c(9)),
-                                    artifact.type = "Mail")
+    mail.data.expected = data.frame(author.name = c("Thomas", "Olaf"),
+                                    author.email = c("thomas@example.org", "olaf@example.org"),
+                                    message.id = c("<65a1sf31sagd684dfv31@mail.gmail.com>", "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>"),
+                                    date = get.date.from.string(c("2016-07-12 16:04:40", "2016-07-12 16:05:37")),
+                                    date.offset = as.integer(c(100, 200)),
+                                    subject = c("Re: Fw: busybox 2 tab", "Re: Fw: busybox 10"),
+                                    thread = sprintf("<thread-%s>", c(9, 9)),
+                                    artifact.type = c("Mail", "Mail"))
 
     commit.data = x$get.project.data()$get.commits()
     rownames(commit.data) = 1:nrow(commit.data)

--- a/tests/test-networks-equal-constructions.R
+++ b/tests/test-networks-equal-constructions.R
@@ -13,6 +13,7 @@
 ##
 ## Copyright 2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2018 by Claus Hunsen <hunsen@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -86,7 +87,8 @@ compare.edge.and.vertex.lists = function(split.author.networks.one = NULL, split
     }
 }
 
-test_that("Compare the bipartite and author network constructed in two ways with author/artifact relation 'cochange'", {
+patrick::with_parameters_test_that("Compare the bipartite and author network constructed in two ways
+                                    with author/artifact relation 'cochange', ", {
 
     ## configuration object for the datapath
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -106,7 +108,7 @@ test_that("Compare the bipartite and author network constructed in two ways with
 
     ## split the networks
     split.networks = split.networks.time.based(networks = list(author.network, bipartite.network),
-                                               time.period = splitting.period, sliding.window = FALSE)
+                                               time.period = splitting.period, sliding.window = test.sliding.window)
 
     ## separate the author and bipartite networks
     split.author.networks.one = split.networks[[1]]
@@ -116,7 +118,8 @@ test_that("Compare the bipartite and author network constructed in two ways with
     multi.network = network.builder$get.multi.network()
 
     ## split the network
-    multi.network.split = split.network.time.based(network = multi.network, time.period = splitting.period)
+    multi.network.split = split.network.time.based(network = multi.network, time.period = splitting.period,
+                                                   sliding.window = test.sliding.window)
 
     split.author.networks.two = list()
     split.bipartite.networks.two = list()
@@ -134,10 +137,13 @@ test_that("Compare the bipartite and author network constructed in two ways with
     ## created with different approaches
     compare.edge.and.vertex.lists(split.author.networks.one, split.author.networks.two,
                                    split.bipartite.networks.one, split.bipartite.networks.two)
-})
+}, patrick::cases(
+    "sliding window: FALSE"  = list(test.sliding.window = FALSE),
+    "sliding window: TRUE" = list(test.sliding.window = TRUE)
+))
 
-test_that("Compare the bipartite and author network constructed in two ways with author relation 'mail' and artifact relation
-          'cochange'", {
+patrick::with_parameters_test_that("Compare the bipartite and author network constructed in two ways
+                                    with author relation 'mail' and artifact relation 'cochange', ", {
 
     ## configuration object for the datapath
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -158,7 +164,7 @@ test_that("Compare the bipartite and author network constructed in two ways with
 
     ## split the networks
     split.networks = split.networks.time.based(networks = list(author.network, bipartite.network),
-                                               time.period = splitting.period, sliding.window = FALSE)
+                                               time.period = splitting.period, sliding.window = test.sliding.window)
 
     ## separate the author and bipartite networks
     split.author.networks.one = split.networks[[1]]
@@ -168,7 +174,8 @@ test_that("Compare the bipartite and author network constructed in two ways with
     multi.network = network.builder$get.multi.network()
 
     ## split the network
-    multi.network.split = split.network.time.based(network = multi.network, time.period = splitting.period)
+    multi.network.split = split.network.time.based(network = multi.network, time.period = splitting.period,
+                                                   sliding.window = test.sliding.window)
 
     split.author.networks.two = list()
     split.bipartite.networks.two = list()
@@ -187,9 +194,13 @@ test_that("Compare the bipartite and author network constructed in two ways with
     ## created with different approaches
     compare.edge.and.vertex.lists(split.author.networks.one, split.author.networks.two,
                                    split.bipartite.networks.one, split.bipartite.networks.two)
-})
+}, patrick::cases(
+    "sliding window: FALSE" = list(test.sliding.window = FALSE),
+    "sliding window: TRUE" = list(test.sliding.window = TRUE)
+))
 
-test_that("Compare the bipartite and author network constructed in two ways with author and artifact relation 'mail'", {
+patrick::with_parameters_test_that("Compare the bipartite and author network constructed in two ways
+                                    with author and artifact relation 'mail', ", {
 
     ## configuration object for the datapath
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -210,7 +221,7 @@ test_that("Compare the bipartite and author network constructed in two ways with
 
     ## split the networks
     split.networks = split.networks.time.based(networks = list(author.network, bipartite.network),
-                                               time.period = splitting.period, sliding.window = FALSE)
+                                               time.period = splitting.period, sliding.window = test.sliding.window)
 
     ## separate the author and bipartite networks
     split.author.networks.one = split.networks[[1]]
@@ -220,7 +231,8 @@ test_that("Compare the bipartite and author network constructed in two ways with
     multi.network = network.builder$get.multi.network()
 
     ## split the network
-    multi.network.split = split.network.time.based(network = multi.network, time.period = splitting.period)
+    multi.network.split = split.network.time.based(network = multi.network, time.period = splitting.period,
+                                                   sliding.window = test.sliding.window)
 
     split.author.networks.two = list()
     split.bipartite.networks.two = list()
@@ -239,4 +251,7 @@ test_that("Compare the bipartite and author network constructed in two ways with
     ## created with different approaches
     compare.edge.and.vertex.lists(split.author.networks.one, split.author.networks.two,
                                    split.bipartite.networks.one, split.bipartite.networks.two)
-})
+}, patrick::cases(
+    "sliding window: FALSE" = list(test.sliding.window = FALSE),
+    "sliding window: TRUE" = list(test.sliding.window = TRUE)
+))

--- a/tests/test-split-sliding-window.R
+++ b/tests/test-split-sliding-window.R
@@ -14,13 +14,14 @@
 ## Copyright 2017-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 ## All Rights Reserved.
 
 
-context("Splitting functionality.")
+context("Splitting functionality, using sliding windows.")
 
 ##
 ## Context
@@ -43,13 +44,6 @@ if (!dir.exists(CF.DATA)) CF.DATA = file.path(".", "tests", "codeface-data")
 ## instead of the networks that can be constructed from these data items!
 
 
-##
-## TODO
-##
-
-## - net.conf$update.values(list(pasta = TRUE, synchronicity = TRUE))
-
-
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
 ## Split data --------------------------------------------------------------
 
@@ -58,10 +52,10 @@ if (!dir.exists(CF.DATA)) CF.DATA = file.path(".", "tests", "codeface-data")
 ## * * time period ---------------------------------------------------------
 
 ##
-## Tests for split.data.time.based(..., split.basis = 'commits')
+## Tests for split.data.time.based(..., split.basis = 'commits'), using sliding windows
 ##
 
-test_that("Split a data object time-based (split.basis == 'commits').", {
+test_that("Split a data object time-based (split.basis == 'commits', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -80,42 +74,55 @@ test_that("Split a data object time-based (split.basis == 'commits').", {
 
     ## split data
     results = split.data.time.based(project.data, time.period = "3 min",
-                                    split.basis = "commits", sliding.window = FALSE)
+                                    split.basis = "commits", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
         "2016-07-12 15:58:59-2016-07-12 16:01:59",
+        "2016-07-12 16:00:29-2016-07-12 16:03:29",
         "2016-07-12 16:01:59-2016-07-12 16:04:59",
+        "2016-07-12 16:03:29-2016-07-12 16:06:29",
         "2016-07-12 16:04:59-2016-07-12 16:06:33"
     )
     result = proj.conf$get.value("ranges")
+
     expect_equal(result, expected, info = "Time ranges.")
 
     ## check data for all ranges
     expected.data = list(
         commits = list(
             "2016-07-12 15:58:59-2016-07-12 16:01:59" = data$commits[1:2, ],
+            "2016-07-12 16:00:29-2016-07-12 16:03:29" = data$commits[2, ],
             "2016-07-12 16:01:59-2016-07-12 16:04:59" = data$commits[0, ],
+            "2016-07-12 16:03:29-2016-07-12 16:06:29" = data$commits[3:5, ],
             "2016-07-12 16:04:59-2016-07-12 16:06:33" = data$commits[3:8, ]
         ),
         mails = list(
             "2016-07-12 15:58:59-2016-07-12 16:01:59" = data$mails[0, ],
+            "2016-07-12 16:00:29-2016-07-12 16:03:29" = data$mails[0, ],
             "2016-07-12 16:01:59-2016-07-12 16:04:59" = data$mails[rownames(data$mails) == 16, ],
+            "2016-07-12 16:03:29-2016-07-12 16:06:29" = data$mails[rownames(data$mails) %in% c(16, 17), ],
             "2016-07-12 16:04:59-2016-07-12 16:06:33" = data$mails[rownames(data$mails) == 17, ]
         ),
         issues = list(
             "2016-07-12 15:58:59-2016-07-12 16:01:59" = data$issues[rownames(data$issues) %in% c(14, 20:22), ],
-            "2016-07-12 16:01:59-2016-07-12 16:04:59" = data$issues[rownames(data$issues) %in% c(15,29), ],
+            "2016-07-12 16:00:29-2016-07-12 16:03:29" = data$issues[rownames(data$issues) %in% c(14:15), ],
+            "2016-07-12 16:01:59-2016-07-12 16:04:59" = data$issues[rownames(data$issues) %in% c(15, 29), ],
+            "2016-07-12 16:03:29-2016-07-12 16:06:29" = data$issues[rownames(data$issues) == 29, ],
             "2016-07-12 16:04:59-2016-07-12 16:06:33" = data$issues[rownames(data$issues) == 23, ]
         ),
         synchronicity = list(
             "2016-07-12 15:58:59-2016-07-12 16:01:59" = data$synchronicity,
+            "2016-07-12 16:00:29-2016-07-12 16:03:29" = data$synchronicity,
             "2016-07-12 16:01:59-2016-07-12 16:04:59" = data$synchronicity,
+            "2016-07-12 16:03:29-2016-07-12 16:06:29" = data$synchronicity,
             "2016-07-12 16:04:59-2016-07-12 16:06:33" = data$synchronicity
         ),
         pasta = list(
             "2016-07-12 15:58:59-2016-07-12 16:01:59" = data$pasta,
+            "2016-07-12 16:00:29-2016-07-12 16:03:29" = data$pasta,
             "2016-07-12 16:01:59-2016-07-12 16:04:59" = data$pasta,
+            "2016-07-12 16:03:29-2016-07-12 16:06:29" = data$pasta,
             "2016-07-12 16:04:59-2016-07-12 16:06:33" = data$pasta
         )
     )
@@ -126,17 +133,16 @@ test_that("Split a data object time-based (split.basis == 'commits').", {
         synchronicity = lapply(results, function(cf.data) cf.data$get.synchronicity()),
         pasta = lapply(results, function(cf.data) cf.data$get.pasta())
     )
-
     expect_equal(results.data, expected.data, info = "Data for ranges.")
 
 })
 
 
 ##
-## Tests for split.data.time.based(..., split.basis = 'mails')
+## Tests for split.data.time.based(..., split.basis = 'mails'), using sliding windows
 ##
 
-test_that("Split a data object time-based (split.basis == 'mails').", {
+test_that("Split a data object time-based (split.basis == 'mails', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -155,13 +161,16 @@ test_that("Split a data object time-based (split.basis == 'mails').", {
 
     ## split data
     results = split.data.time.based(project.data, time.period = "3 years",
-                                    split.basis = "mails", sliding.window = FALSE)
+                                    split.basis = "mails", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
         "2004-10-09 18:38:13-2007-10-10 12:38:13",
+        "2006-04-10 15:38:13-2009-04-10 09:38:13",
         "2007-10-10 12:38:13-2010-10-10 06:38:13",
+        "2009-04-10 09:38:13-2012-04-10 03:38:13",
         "2010-10-10 06:38:13-2013-10-10 00:38:13",
+        "2012-04-10 03:38:13-2015-04-10 21:38:13",
         "2013-10-10 00:38:13-2016-07-12 16:05:38"
     )
     result = proj.conf$get.value("ranges")
@@ -172,32 +181,47 @@ test_that("Split a data object time-based (split.basis == 'mails').", {
     expected.data = list(
         commits = list(
             "2004-10-09 18:38:13-2007-10-10 12:38:13" = data$commits[0, ],
+            "2006-04-10 15:38:13-2009-04-10 09:38:13" = data$commits[0, ],
             "2007-10-10 12:38:13-2010-10-10 06:38:13" = data$commits[0, ],
+            "2009-04-10 09:38:13-2012-04-10 03:38:13" = data$commits[0, ],
             "2010-10-10 06:38:13-2013-10-10 00:38:13" = data$commits[0, ],
+            "2012-04-10 03:38:13-2015-04-10 21:38:13" = data$commits[0, ],
             "2013-10-10 00:38:13-2016-07-12 16:05:38" = data$commits[1:2, ]
         ),
         mails = list(
             "2004-10-09 18:38:13-2007-10-10 12:38:13" = data$mails[rownames(data$mails) %in% 1:2, ],
+            "2006-04-10 15:38:13-2009-04-10 09:38:13" = data$mails[0, ],
             "2007-10-10 12:38:13-2010-10-10 06:38:13" = data$mails[rownames(data$mails) %in% 3:12, ],
+            "2009-04-10 09:38:13-2012-04-10 03:38:13" = data$mails[rownames(data$mails) %in% 3:12, ],
             "2010-10-10 06:38:13-2013-10-10 00:38:13" = data$mails[0, ],
+            "2012-04-10 03:38:13-2015-04-10 21:38:13" = data$mails[0, ],
             "2013-10-10 00:38:13-2016-07-12 16:05:38" = data$mails[rownames(data$mails) %in% 13:17, ]
         ),
         issues = list(
             "2004-10-09 18:38:13-2007-10-10 12:38:13" = data$issues[0, ],
+            "2006-04-10 15:38:13-2009-04-10 09:38:13" = data$issues[0, ],
             "2007-10-10 12:38:13-2010-10-10 06:38:13" = data$issues[0, ],
+            "2009-04-10 09:38:13-2012-04-10 03:38:13" = data$issues[0, ],
             "2010-10-10 06:38:13-2013-10-10 00:38:13" = data$issues[rownames(data$issues) %in% 1:13, ],
+            "2012-04-10 03:38:13-2015-04-10 21:38:13" = data$issues[rownames(data$issues) %in% 1:13, ],
             "2013-10-10 00:38:13-2016-07-12 16:05:38" = data$issues[rownames(data$issues) %in% c(14:15, 20:22, 27:29), ]
         ),
         synchronicity = list(
             "2004-10-09 18:38:13-2007-10-10 12:38:13" = data$synchronicity,
+            "2006-04-10 15:38:13-2009-04-10 09:38:13" = data$synchronicity,
             "2007-10-10 12:38:13-2010-10-10 06:38:13" = data$synchronicity,
+            "2009-04-10 09:38:13-2012-04-10 03:38:13" = data$synchronicity,
             "2010-10-10 06:38:13-2013-10-10 00:38:13" = data$synchronicity,
+            "2012-04-10 03:38:13-2015-04-10 21:38:13" = data$synchronicity,
             "2013-10-10 00:38:13-2016-07-12 16:05:38" = data$synchronicity
         ),
         pasta = list(
             "2004-10-09 18:38:13-2007-10-10 12:38:13" = data$pasta,
+            "2006-04-10 15:38:13-2009-04-10 09:38:13" = data$pasta,
             "2007-10-10 12:38:13-2010-10-10 06:38:13" = data$pasta,
+            "2009-04-10 09:38:13-2012-04-10 03:38:13" = data$pasta,
             "2010-10-10 06:38:13-2013-10-10 00:38:13" = data$pasta,
+            "2012-04-10 03:38:13-2015-04-10 21:38:13" = data$pasta,
             "2013-10-10 00:38:13-2016-07-12 16:05:38" = data$pasta
         )
     )
@@ -208,17 +232,16 @@ test_that("Split a data object time-based (split.basis == 'mails').", {
         synchronicity = lapply(results, function(cf.data) cf.data$get.synchronicity()),
         pasta = lapply(results, function(cf.data) cf.data$get.pasta())
     )
-
     expect_equal(results.data, expected.data, info = "Data for ranges.")
 
 })
 
 
 ##
-## Tests for split.data.time.based(..., split.basis = 'issues')
+## Tests for split.data.time.based(..., split.basis = 'issues'), using sliding windows
 ##
 
-test_that("Split a data object time-based (split.basis == 'issues').", {
+test_that("Split a data object time-based (split.basis == 'issues', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -237,13 +260,14 @@ test_that("Split a data object time-based (split.basis == 'issues').", {
 
     ## split data
     results = split.data.time.based(project.data, time.period = "2 years",
-                                    split.basis = "issues", sliding.window = FALSE)
+                                    split.basis = "issues", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
         "2013-04-21 23:52:09-2015-04-22 11:52:09",
+        "2014-04-22 05:52:09-2016-04-21 17:52:09",
         "2015-04-22 11:52:09-2017-04-21 23:52:09",
-        "2017-04-21 23:52:09-2017-05-23 12:32:40"
+        "2016-04-21 17:52:09-2017-05-23 12:32:40"
     )
     result = proj.conf$get.value("ranges")
 
@@ -253,28 +277,33 @@ test_that("Split a data object time-based (split.basis == 'issues').", {
     expected.data = list(
         commits = list(
             "2013-04-21 23:52:09-2015-04-22 11:52:09" = data$commits[0, ],
+            "2014-04-22 05:52:09-2016-04-21 17:52:09" = data$commits[0, ],
             "2015-04-22 11:52:09-2017-04-21 23:52:09" = data$commits,
-            "2017-04-21 23:52:09-2017-05-23 12:32:40" = data$commits[0, ]
+            "2016-04-21 17:52:09-2017-05-23 12:32:40" = data$commits
         ),
         mails = list(
             "2013-04-21 23:52:09-2015-04-22 11:52:09" = data$mails[0, ],
+            "2014-04-22 05:52:09-2016-04-21 17:52:09" = data$mails[0, ],
             "2015-04-22 11:52:09-2017-04-21 23:52:09" = data$mails[rownames(data$mails) %in% 14:17, ],
-            "2017-04-21 23:52:09-2017-05-23 12:32:40" = data$mails[0, ]
+            "2016-04-21 17:52:09-2017-05-23 12:32:40" = data$mails[rownames(data$mails) %in% 14:17, ]
         ),
         issues = list(
             "2013-04-21 23:52:09-2015-04-22 11:52:09" = data$issues[rownames(data$issues) %in% 1:13, ],
+            "2014-04-22 05:52:09-2016-04-21 17:52:09" = data$issues[0, ],
             "2015-04-22 11:52:09-2017-04-21 23:52:09" = data$issues[rownames(data$issues) %in% 14:34, ],
-            "2017-04-21 23:52:09-2017-05-23 12:32:40" = data$issues[rownames(data$issues) %in% 35:36, ]
+            "2016-04-21 17:52:09-2017-05-23 12:32:40" = data$issues[rownames(data$issues) %in% 14:36, ]
         ),
         synchronicity = list(
             "2013-04-21 23:52:09-2015-04-22 11:52:09" = data$synchronicity,
+            "2014-04-22 05:52:09-2016-04-21 17:52:09" = data$synchronicity,
             "2015-04-22 11:52:09-2017-04-21 23:52:09" = data$synchronicity,
-            "2017-04-21 23:52:09-2017-05-23 12:32:40" = data$synchronicity
+            "2016-04-21 17:52:09-2017-05-23 12:32:40" = data$synchronicity
         ),
         pasta = list(
             "2013-04-21 23:52:09-2015-04-22 11:52:09" = data$pasta,
+            "2014-04-22 05:52:09-2016-04-21 17:52:09" = data$pasta,
             "2015-04-22 11:52:09-2017-04-21 23:52:09" = data$pasta,
-            "2017-04-21 23:52:09-2017-05-23 12:32:40" = data$pasta
+            "2016-04-21 17:52:09-2017-05-23 12:32:40" = data$pasta
         )
     )
     results.data = list(
@@ -284,7 +313,6 @@ test_that("Split a data object time-based (split.basis == 'issues').", {
         synchronicity = lapply(results, function(cf.data) cf.data$get.synchronicity()),
         pasta = lapply(results, function(cf.data) cf.data$get.pasta())
     )
-
     expect_equal(results.data, expected.data, info = "Data for ranges.")
 
 })
@@ -292,10 +320,10 @@ test_that("Split a data object time-based (split.basis == 'issues').", {
 ## * * bins ----------------------------------------------------------------
 
 ##
-## Tests for split.data.time.based(..., bins = ...)
+## Tests for split.data.time.based(..., bins = ...), sliding windows parameter ignored
 ##
 
-test_that("Split a data object time-based (bins == ... ).", {
+test_that("Split a data object time-based (bins == ... , sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -313,12 +341,14 @@ test_that("Split a data object time-based (bins == ... ).", {
     )
 
     ## split data
-    results = split.data.time.based(project.data, bins = c("2016-01-01 00:00:00", "2016-12-31 23:59:59"),
-                                    split.basis = "mails", sliding.window = FALSE)
+    results = split.data.time.based(project.data, bins = c("2016-01-01 00:00:00", "2016-12-31 23:59:59",
+                                                           "2017-06-03 03:03:03"),
+                                    split.basis = "mails", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
-        "2016-01-01 00:00:00-2016-12-31 23:59:59"
+        "2016-01-01 00:00:00-2016-12-31 23:59:59",
+        "2016-12-31 23:59:59-2017-06-03 03:03:03"
     )
     result = proj.conf$get.value("ranges")
     expect_equal(result, expected, info = "Time ranges.")
@@ -326,134 +356,25 @@ test_that("Split a data object time-based (bins == ... ).", {
     ## check data for all ranges
     expected.data = list(
         commits = list(
-            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$commits
+            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$commits,
+            "2016-12-31 23:59:59-2017-06-03 03:03:03" = data$commits[0, ]
         ),
         mails = list(
-            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$mails[rownames(data$mails) %in% 13:17, ]
+            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$mails[rownames(data$mails) %in% 13:17, ],
+            "2016-12-31 23:59:59-2017-06-03 03:03:03" = data$mails[0, ]
         ),
         issues = list(
-            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$issues[rownames(data$issues) %in% 14:34, ]
+            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$issues[rownames(data$issues) %in% 14:34, ],
+            "2016-12-31 23:59:59-2017-06-03 03:03:03" = data$issues[rownames(data$issues) %in% 35:36, ]
         ),
         synchronicity = list(
-            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$synchronicity
+            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$synchronicity,
+            "2016-12-31 23:59:59-2017-06-03 03:03:03" = data$synchronicity
         ),
         pasta = list(
-            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$pasta
+            "2016-01-01 00:00:00-2016-12-31 23:59:59" = data$pasta,
+            "2016-12-31 23:59:59-2017-06-03 03:03:03" = data$pasta
         )
-    )
-    results.data = list(
-        commits = lapply(results, function(cf.data) cf.data$get.commits()),
-        mails = lapply(results, function(cf.data) cf.data$get.mails()),
-        issues = lapply(results, function(cf.data) cf.data$get.issues()),
-        synchronicity = lapply(results, function(cf.data) cf.data$get.synchronicity()),
-        pasta = lapply(results, function(cf.data) cf.data$get.pasta())
-    )
-
-    expect_equal(results.data, expected.data, info = "Data for ranges.")
-
-})
-
-## * * ranges --------------------------------------------------------------
-
-##
-## Test splitting data by network names.
-##
-
-test_that("Test splitting data by networks", {
-    ## configuration and data objects
-    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
-    proj.conf$update.value("commits.filter.base.artifact", FALSE)
-    net.conf = NetworkConf$new()
-    net.conf$update.values(list(author.relation = "cochange", simplify = FALSE))
-
-    ## construct project data
-    project.data = ProjectData$new(proj.conf)
-
-    ## split data
-    mybins = get.date.from.string(c("2016-07-12 15:00:00", "2016-07-12 16:00:00",
-                                    "2016-07-12 16:05:00", "2016-10-05 09:00:00"))
-    input.data = split.data.time.based(project.data, bins = mybins)
-    input.data.network = lapply(input.data, function(d) NetworkBuilder$new(d, net.conf)$get.author.network())
-
-    ## split data by networks
-    aggregation.level = c("range", "cumulative", "all.ranges",
-                          "project.cumulative", "project.all.ranges",
-                          "complete")
-    results = lapply(aggregation.level, function(level)
-        split.data.by.networks(input.data.network, project.data, level)
-    )
-    names(results) = aggregation.level
-
-    ## construct expected ranges
-    expected.ranges = list(
-        range = c("2016-07-12 15:00:00-2016-07-12 16:00:00",
-                  "2016-07-12 16:00:00-2016-07-12 16:05:00",
-                  "2016-07-12 16:05:00-2016-10-05 09:00:00"),
-        cumulative = c("2016-07-12 15:00:00-2016-07-12 16:00:00",
-                       "2016-07-12 15:00:00-2016-07-12 16:05:00",
-                       "2016-07-12 15:00:00-2016-10-05 09:00:00"),
-        all.ranges = c("2016-07-12 15:00:00-2016-10-05 09:00:00",
-                       "2016-07-12 15:00:00-2016-10-05 09:00:00",
-                       "2016-07-12 15:00:00-2016-10-05 09:00:00"),
-        project.cumulative = c("2004-10-09 18:38:13-2016-07-12 16:00:00",
-                               "2004-10-09 18:38:13-2016-07-12 16:05:00",
-                               "2004-10-09 18:38:13-2016-10-05 09:00:00"),
-        project.all.ranges = c("2004-10-09 18:38:13-2016-10-05 09:00:00",
-                               "2004-10-09 18:38:13-2016-10-05 09:00:00",
-                               "2004-10-09 18:38:13-2016-10-05 09:00:00"),
-        complete = c("2004-10-09 18:38:13-2017-05-23 12:32:40",
-                     "2004-10-09 18:38:13-2017-05-23 12:32:40",
-                     "2004-10-09 18:38:13-2017-05-23 12:32:40")
-    )
-
-    ## test the ranges
-    test.each.network = function(aggregation.level) {
-        result.data = results[[aggregation.level]]
-        expected.range.names = expected.ranges[[aggregation.level]]
-
-
-
-        lapply(seq_along(result.data), function(i) {
-            result.entry = result.data[[i]]
-
-            expect_true(igraph::identical_graphs(result.entry[["network"]], input.data.network[[i]]))
-            expect_equal(result.entry[["data"]]$get.range(), expected.range.names[[i]])
-        })
-    }
-    lapply(aggregation.level, test.each.network)
-})
-
-##
-## Test splitting data by ranges.
-##
-
-test_that("Test splitting data by ranges", {
-    ## configuration and data objects
-    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
-    proj.conf$update.value("commits.filter.base.artifact", FALSE)
-    net.conf = NetworkConf$new()
-    net.conf$update.values(list(author.relation = "cochange", simplify = FALSE))
-
-    ## construct project data
-    project.data = ProjectData$new(proj.conf)
-
-    ## split data
-    my.bins = get.date.from.string(c("2016-07-12 15:00:00", "2016-07-12 16:00:00",
-                                     "2016-07-12 16:05:00", "2016-10-05 09:00:00"))
-    my.ranges = construct.ranges(my.bins, sliding.window = FALSE)
-    expected.results = split.data.time.based(project.data, bins = my.bins)
-    results = split.data.time.based.by.ranges(project.data, my.ranges)
-
-    ## check time ranges
-    expect_equal(names(results), my.ranges, info = "Time ranges.")
-
-    ## check data for all ranges
-    expected.data = list(
-        commits = lapply(expected.results, function(cf.data) cf.data$get.commits()),
-        mails = lapply(expected.results, function(cf.data) cf.data$get.mails()),
-        issues = lapply(expected.results, function(cf.data) cf.data$get.issues()),
-        synchronicity = lapply(expected.results, function(cf.data) cf.data$get.synchronicity()),
-        pasta = lapply(expected.results, function(cf.data) cf.data$get.pasta())
     )
     results.data = list(
         commits = lapply(results, function(cf.data) cf.data$get.commits()),
@@ -469,10 +390,10 @@ test_that("Test splitting data by ranges", {
 ## * activity-based --------------------------------------------------------
 
 ##
-## Tests for split.data.activity.based(..., activity.type = 'commits')
+## Tests for split.data.activity.based(..., activity.type = 'commits') using sliding windows
 ##
 
-test_that("Split a data object activity-based (activity.type = 'commits').", {
+test_that("Split a data object activity-based (activity.type = 'commits', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -491,13 +412,14 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
 
     ## split data
     results = split.data.activity.based(project.data, activity.amount = 3,
-                                    activity.type = "commits", sliding.window = FALSE)
+                                        activity.type = "commits", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
         "2016-07-12 15:58:59-2016-07-12 16:06:10",
+        "2016-07-12 16:00:45-2016-07-12 16:06:20",
         "2016-07-12 16:06:10-2016-07-12 16:06:32",
-        "2016-07-12 16:06:32-2016-07-12 16:06:33"
+        "2016-07-12 16:06:20-2016-07-12 16:06:33"
     )
     result = proj.conf$get.value("ranges")
     expect_equal(result, expected, info = "Time ranges (activity.amount).")
@@ -506,28 +428,33 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
     expected.data = list(
         commits = list(
             "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$commits[1:3, ],
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$commits[2:4, ],
             "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$commits[4:6, ],
-            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$commits[7:8, ]
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$commits[5:8, ]
         ),
         mails = list(
             "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$mails[rownames(data$mails) %in% 16:17, ],
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$mails[rownames(data$mails) %in% 16:17, ],
             "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$mails[0, ],
-            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$mails[0, ]
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$mails[0, ]
         ),
         issues = list(
             "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$issues[rownames(data$issues) %in% c(14:15, 20:22, 29), ],
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$issues[rownames(data$issues) %in% c(14:15, 29), ],
             "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$issues[rownames(data$issues) == 23, ],
-            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$issues[0, ]
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$issues[rownames(data$issues) == 23, ]
         ),
         synchronicity = list(
             "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$synchronicity,
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$synchronicity,
             "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$synchronicity,
-            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$synchronicity
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$synchronicity
         ),
         pasta = list(
             "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$pasta,
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$pasta,
             "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$pasta,
-            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$pasta
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$pasta
         )
     )
     results.data = list(
@@ -545,7 +472,7 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
 
     ## split data
     results = split.data.activity.based(project.data, activity.amount = nrow(data$commits) + 10,
-                                        activity.type = "commits", sliding.window = FALSE)
+                                        activity.type = "commits", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
@@ -582,12 +509,12 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
     expect_equal(results.data, expected.data, info = "Data for ranges for too-large activity amount (activity.amount).")
 
     ##
-    ## split by number of windows
+    ## split by number of windows (i.e., ignoring sliding windows)
     ##
 
     ## split data
     results = split.data.activity.based(project.data, number.windows = 2,
-                                        activity.type = "commits", sliding.window = FALSE)
+                                        activity.type = "commits", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
@@ -629,26 +556,117 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
     )
     expect_equal(results.data, expected.data, info = "Data for ranges (number.windows).")
 
-    ## too large number of windows
+    ## too large number of windows (i.e., ignoring sliding windows)
 
     expect_error(
-        split.data.activity.based(project.data, activity.type = "commits", number.windows = nrow(project.data$get.commits()) + 10),
+        split.data.activity.based(project.data, activity.type = "commits",
+                                  number.windows = nrow(project.data$get.commits()) + 10, sliding.window = TRUE),
         info = "Error expected (number.windows) (1)."
     )
 
     expect_error(
-        split.data.activity.based(project.data, activity.type = "commits", number.windows = 0),
+        split.data.activity.based(project.data, activity.type = "commits", number.windows = 0, sliding.window = TRUE),
         info = "Error expected (number.windows) (2)."
     )
 
 })
 
+test_that("Split a data object activity-based (activity.type = 'commits', sliding.window = TRUE), continued.", {
+
+    ## configuration objects
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.conf$update.value("issues.only.comments", FALSE)
+    net.conf = NetworkConf$new()
+
+    ## data object
+    project.data = ProjectData$new(proj.conf)
+
+    ## add one commit to the commit data having same date as latest commit
+    commit.data = project.data$get.commits()
+    latest.commit = commit.data[nrow(commit.data), ]
+    latest.commit[1, "commit.id"] = "<commit-added>"
+    latest.commit[1, "hash"] = "abcdefghijklmnopqrstuvxyz"
+    commit.data = rbind(commit.data, latest.commit)
+    project.data$set.commits(commit.data)
+
+    data = list(
+        commits = project.data$get.commits(),
+        mails = project.data$get.mails(),
+        issues = project.data$get.issues(),
+        synchronicity = project.data$get.synchronicity(),
+        pasta = project.data$get.pasta()
+    )
+
+    ## split data
+    results = split.data.activity.based(project.data, activity.amount = 3,
+                                        activity.type = "commits", sliding.window = TRUE)
+
+    ## check time ranges
+    expected = c(
+        "2016-07-12 15:58:59-2016-07-12 16:06:10",
+        "2016-07-12 16:00:45-2016-07-12 16:06:20",
+        "2016-07-12 16:06:10-2016-07-12 16:06:32",
+        "2016-07-12 16:06:20-2016-07-12 16:06:33",
+        "2016-07-12 16:06:32-2016-07-12 16:06:33"
+    )
+    result = proj.conf$get.value("ranges")
+    expect_equal(result, expected, info = "Time ranges (activity.amount).")
+
+    ## check data for all ranges
+    expected.data = list(
+        commits = list(
+            "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$commits[1:3, ],
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$commits[2:4, ],
+            "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$commits[4:6, ],
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$commits[5:8, ],
+            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$commits[7:9, ]
+        ),
+        mails = list(
+            "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$mails[rownames(data$mails) %in% 16:17, ],
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$mails[rownames(data$mails) %in% 16:17, ],
+            "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$mails[0, ],
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$mails[0, ],
+            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$mails[0, ]
+        ),
+        issues = list(
+            "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$issues[rownames(data$issues) %in% c(14:15, 20:22, 29), ],
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$issues[rownames(data$issues) %in% c(14:15, 29), ],
+            "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$issues[rownames(data$issues) == 23, ],
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$issues[rownames(data$issues) == 23, ],
+            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$issues[0, ]
+        ),
+        synchronicity = list(
+            "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$synchronicity,
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$synchronicity,
+            "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$synchronicity,
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$synchronicity,
+            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$synchronicity
+        ),
+        pasta = list(
+            "2016-07-12 15:58:59-2016-07-12 16:06:10" = data$pasta,
+            "2016-07-12 16:00:45-2016-07-12 16:06:20" = data$pasta,
+            "2016-07-12 16:06:10-2016-07-12 16:06:32" = data$pasta,
+            "2016-07-12 16:06:20-2016-07-12 16:06:33" = data$pasta,
+            "2016-07-12 16:06:32-2016-07-12 16:06:33" = data$pasta
+        )
+    )
+    results.data = list(
+        commits = lapply(results, function(cf.data) cf.data$get.commits()),
+        mails = lapply(results, function(cf.data) cf.data$get.mails()),
+        issues = lapply(results, function(cf.data) cf.data$get.issues()),
+        synchronicity = lapply(results, function(cf.data) cf.data$get.synchronicity()),
+        pasta = lapply(results, function(cf.data) cf.data$get.pasta())
+    )
+    expect_equal(results.data, expected.data, info = "Data for ranges (activity.amount).")
+
+})
+
 
 ##
-## Tests for split.data.activity.based(..., activity.type = 'mails')
+## Tests for split.data.activity.based(..., activity.type = 'mails') using sliding windows
 ##
 
-test_that("Split a data object activity-based (activity.type = 'mails').", {
+test_that("Split a data object activity-based (activity.type = 'mails', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -667,16 +685,20 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
 
     ## split data
     results = split.data.activity.based(project.data, activity.amount = 3,
-                                    activity.type = "mails", sliding.window = FALSE)
+                                        activity.type = "mails", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
         "2004-10-09 18:38:13-2010-07-12 11:05:35",
+        "2005-02-09 18:49:49-2010-07-12 12:05:34",
         "2010-07-12 11:05:35-2010-07-12 12:05:41",
+        "2010-07-12 12:05:34-2010-07-12 12:05:42",
         "2010-07-12 12:05:41-2010-07-12 12:05:44",
+        "2010-07-12 12:05:42-2010-07-12 12:05:45",
         "2010-07-12 12:05:44-2016-07-12 15:58:40",
+        "2010-07-12 12:05:45-2016-07-12 15:58:50",
         "2016-07-12 15:58:40-2016-07-12 16:05:37",
-        "2016-07-12 16:05:37-2016-07-12 16:05:38"
+        "2016-07-12 15:58:50-2016-07-12 16:05:38"
     )
     result = proj.conf$get.value("ranges")
     expect_equal(result, expected, info = "Time ranges.")
@@ -685,43 +707,63 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
     expected.data = list(
         commits = list(
             "2004-10-09 18:38:13-2010-07-12 11:05:35" = data$commits[0, ],
+            "2005-02-09 18:49:49-2010-07-12 12:05:34" = data$commits[0, ],
             "2010-07-12 11:05:35-2010-07-12 12:05:41" = data$commits[0, ],
+            "2010-07-12 12:05:34-2010-07-12 12:05:42" = data$commits[0, ],
             "2010-07-12 12:05:41-2010-07-12 12:05:44" = data$commits[0, ],
+            "2010-07-12 12:05:42-2010-07-12 12:05:45" = data$commits[0, ],
             "2010-07-12 12:05:44-2016-07-12 15:58:40" = data$commits[0, ],
+            "2010-07-12 12:05:45-2016-07-12 15:58:50" = data$commits[0, ],
             "2016-07-12 15:58:40-2016-07-12 16:05:37" = data$commits[1:2, ],
-            "2016-07-12 16:05:37-2016-07-12 16:05:38" = data$commits[0, ]
+            "2016-07-12 15:58:50-2016-07-12 16:05:38" = data$commits[1:2, ]
         ),
         mails = list(
             "2004-10-09 18:38:13-2010-07-12 11:05:35" = data$mails[rownames(data$mails) %in% 1:3, ],
+            "2005-02-09 18:49:49-2010-07-12 12:05:34" = data$mails[rownames(data$mails) %in% 2:4, ],
             "2010-07-12 11:05:35-2010-07-12 12:05:41" = data$mails[rownames(data$mails) %in% 4:6, ],
+            "2010-07-12 12:05:34-2010-07-12 12:05:42" = data$mails[rownames(data$mails) %in% 5:7, ],
             "2010-07-12 12:05:41-2010-07-12 12:05:44" = data$mails[rownames(data$mails) %in% 7:9, ],
+            "2010-07-12 12:05:42-2010-07-12 12:05:45" = data$mails[rownames(data$mails) %in% 8:10, ],
             "2010-07-12 12:05:44-2016-07-12 15:58:40" = data$mails[rownames(data$mails) %in% 10:12, ],
+            "2010-07-12 12:05:45-2016-07-12 15:58:50" = data$mails[rownames(data$mails) %in% c(11:12, 14), ],
             "2016-07-12 15:58:40-2016-07-12 16:05:37" = data$mails[rownames(data$mails) %in% 14:16, ],
-            "2016-07-12 16:05:37-2016-07-12 16:05:38" = data$mails[rownames(data$mails) %in% 17, ]
+            "2016-07-12 15:58:50-2016-07-12 16:05:38" = data$mails[rownames(data$mails) %in% 15:17, ]
         ),
         issues = list(
             "2004-10-09 18:38:13-2010-07-12 11:05:35" = data$issues[0, ],
+            "2005-02-09 18:49:49-2010-07-12 12:05:34" = data$issues[0, ],
             "2010-07-12 11:05:35-2010-07-12 12:05:41" = data$issues[0, ],
+            "2010-07-12 12:05:34-2010-07-12 12:05:42" = data$issues[0, ],
             "2010-07-12 12:05:41-2010-07-12 12:05:44" = data$issues[0, ],
+            "2010-07-12 12:05:42-2010-07-12 12:05:45" = data$issues[0, ],
             "2010-07-12 12:05:44-2016-07-12 15:58:40" = data$issues[rownames(data$issues) %in% c(1:13, 27:28), ],
+            "2010-07-12 12:05:45-2016-07-12 15:58:50" = data$issues[rownames(data$issues) %in% c(1:13, 27:28), ],
             "2016-07-12 15:58:40-2016-07-12 16:05:37" = data$issues[rownames(data$issues) %in% c(14:15, 20:22, 29), ],
-            "2016-07-12 16:05:37-2016-07-12 16:05:38" = data$issues[0, ]
+            "2016-07-12 15:58:50-2016-07-12 16:05:38" = data$issues[rownames(data$issues) %in% c(14:15, 20:22, 29), ]
         ),
         synchronicity = list(
             "2004-10-09 18:38:13-2010-07-12 11:05:35" = data$synchronicity,
+            "2005-02-09 18:49:49-2010-07-12 12:05:34" = data$synchronicity,
             "2010-07-12 11:05:35-2010-07-12 12:05:41" = data$synchronicity,
+            "2010-07-12 12:05:34-2010-07-12 12:05:42" = data$synchronicity,
             "2010-07-12 12:05:41-2010-07-12 12:05:44" = data$synchronicity,
+            "2010-07-12 12:05:42-2010-07-12 12:05:45" = data$synchronicity,
             "2010-07-12 12:05:44-2016-07-12 15:58:40" = data$synchronicity,
+            "2010-07-12 12:05:45-2016-07-12 15:58:50" = data$synchronicity,
             "2016-07-12 15:58:40-2016-07-12 16:05:37" = data$synchronicity,
-            "2016-07-12 16:05:37-2016-07-12 16:05:38" = data$synchronicity
+            "2016-07-12 15:58:50-2016-07-12 16:05:38" = data$synchronicity
         ),
         pasta = list(
             "2004-10-09 18:38:13-2010-07-12 11:05:35" = data$pasta,
+            "2005-02-09 18:49:49-2010-07-12 12:05:34" = data$pasta,
             "2010-07-12 11:05:35-2010-07-12 12:05:41" = data$pasta,
+            "2010-07-12 12:05:34-2010-07-12 12:05:42" = data$pasta,
             "2010-07-12 12:05:41-2010-07-12 12:05:44" = data$pasta,
+            "2010-07-12 12:05:42-2010-07-12 12:05:45" = data$pasta,
             "2010-07-12 12:05:44-2016-07-12 15:58:40" = data$pasta,
+            "2010-07-12 12:05:45-2016-07-12 15:58:50" = data$pasta,
             "2016-07-12 15:58:40-2016-07-12 16:05:37" = data$pasta,
-            "2016-07-12 16:05:37-2016-07-12 16:05:38" = data$pasta
+            "2016-07-12 15:58:50-2016-07-12 16:05:38" = data$pasta
         )
     )
     results.data = list(
@@ -739,7 +781,7 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
 
     ## split data
     results = split.data.activity.based(project.data, activity.amount = nrow(data$mails) + 10,
-                                        activity.type = "mails", sliding.window = FALSE)
+                                        activity.type = "mails", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
@@ -776,12 +818,12 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
     expect_equal(results.data, expected.data, info = "Data for ranges (too-large activity amount).")
 
     ##
-    ## split by number of windows
+    ## split by number of windows (i.e., ignoring sliding windows)
     ##
 
     ## split data
     results = split.data.activity.based(project.data, number.windows = 2,
-                                        activity.type = "mail", sliding.window = FALSE)
+                                        activity.type = "mail", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
@@ -823,25 +865,26 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
     )
     expect_equal(results.data, expected.data, info = "Data for ranges (number.windows).")
 
-    ## too large number of windows
+    ## too large number of windows (i.e., ignoring sliding windows)
 
     expect_error(
-        split.data.activity.based(project.data, activity.type = "mails", number.windows = nrow(project.data$get.mails()) + 10),
+        split.data.activity.based(project.data, activity.type = "mails",
+                                  number.windows = nrow(project.data$get.mails()) + 10, sliding.window = TRUE),
         info = "Error expected (number.windows) (1)."
     )
 
     expect_error(
-        split.data.activity.based(project.data, activity.type = "mails", number.windows = 0),
+        split.data.activity.based(project.data, activity.type = "mails", number.windows = 0, sliding.window = TRUE),
         info = "Error expected (number.windows) (2)."
     )
 })
 
 
 ##
-## Tests for split.data.activity.based(..., activity.type = 'issues')
+## Tests for split.data.activity.based(..., activity.type = 'issues') using sliding windows
 ##
 
-test_that("Split a data object activity-based (activity.type = 'issues').", {
+test_that("Split a data object activity-based (activity.type = 'issues', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -860,13 +903,16 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
 
     ## split data
     results = split.data.activity.based(project.data, activity.amount = 9,
-                                        activity.type = "issues", sliding.window = FALSE)
+                                        activity.type = "issues", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
         "2013-04-21 23:52:09-2013-05-25 06:22:23",
+        "2013-05-06 01:04:34-2016-07-12 15:59:25",
         "2013-05-25 06:22:23-2016-07-12 16:03:59",
+        "2016-07-12 15:59:25-2016-07-27 20:12:08",
         "2016-07-12 16:03:59-2016-10-05 15:30:02",
+        "2016-07-27 20:12:08-2017-05-23 12:31:34",
         "2016-10-05 15:30:02-2017-05-23 12:32:40"
     )
     result = proj.conf$get.value("ranges")
@@ -876,32 +922,47 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
     expected.data = list(
         commits = list(
             "2013-04-21 23:52:09-2013-05-25 06:22:23" = data$commits[0, ],
+            "2013-05-06 01:04:34-2016-07-12 15:59:25" = data$commits[1, ],
             "2013-05-25 06:22:23-2016-07-12 16:03:59" = data$commits[1:2, ],
+            "2016-07-12 15:59:25-2016-07-27 20:12:08" = data$commits[2:8, ],
             "2016-07-12 16:03:59-2016-10-05 15:30:02" = data$commits[3:8, ],
+            "2016-07-27 20:12:08-2017-05-23 12:31:34" = data$commits[0, ],
             "2016-10-05 15:30:02-2017-05-23 12:32:40" = data$commits[0, ]
         ),
         mails = list(
             "2013-04-21 23:52:09-2013-05-25 06:22:23" = data$mails[0, ],
+            "2013-05-06 01:04:34-2016-07-12 15:59:25" = data$mails[rownames(data$mails) %in% 14:15, ],
             "2013-05-25 06:22:23-2016-07-12 16:03:59" = data$mails[rownames(data$mails) %in% 14:15, ],
+            "2016-07-12 15:59:25-2016-07-27 20:12:08" = data$mails[rownames(data$mails) %in% 16:17, ],
             "2016-07-12 16:03:59-2016-10-05 15:30:02" = data$mails[rownames(data$mails) %in% 16:17, ],
+            "2016-07-27 20:12:08-2017-05-23 12:31:34" = data$mails[0, ],
             "2016-10-05 15:30:02-2017-05-23 12:32:40" = data$mails[0, ]
         ),
         issues = list(
             "2013-04-21 23:52:09-2013-05-25 06:22:23" = data$issues[rownames(data$issues) %in% 1:10, ],
+            "2013-05-06 01:04:34-2016-07-12 15:59:25" = data$issues[rownames(data$issues) %in% c(6:13, 27:28), ],
             "2013-05-25 06:22:23-2016-07-12 16:03:59" = data$issues[rownames(data$issues) %in% c(11:15, 20:22, 27:28), ],
+            "2016-07-12 15:59:25-2016-07-27 20:12:08" = data$issues[rownames(data$issues) %in% c(14:17, 20:23, 29),],
             "2016-07-12 16:03:59-2016-10-05 15:30:02" = data$issues[rownames(data$issues) %in% c(16:19, 23:25, 29:30), ],
+            "2016-07-27 20:12:08-2017-05-23 12:31:34" = data$issues[rownames(data$issues) %in% c(18:19, 24:26, 30:34),],
             "2016-10-05 15:30:02-2017-05-23 12:32:40" = data$issues[rownames(data$issues) %in% c(26, 31:36), ]
         ),
         synchronicity = list(
             "2013-04-21 23:52:09-2013-05-25 06:22:23" = data$synchronicity,
+            "2013-05-06 01:04:34-2016-07-12 15:59:25" = data$synchronicity,
             "2013-05-25 06:22:23-2016-07-12 16:03:59" = data$synchronicity,
+            "2016-07-12 15:59:25-2016-07-27 20:12:08" = data$synchronicity,
             "2016-07-12 16:03:59-2016-10-05 15:30:02" = data$synchronicity,
+            "2016-07-27 20:12:08-2017-05-23 12:31:34" = data$synchronicity,
             "2016-10-05 15:30:02-2017-05-23 12:32:40" = data$synchronicity
         ),
         pasta = list(
             "2013-04-21 23:52:09-2013-05-25 06:22:23" = data$pasta,
+            "2013-05-06 01:04:34-2016-07-12 15:59:25" = data$pasta,
             "2013-05-25 06:22:23-2016-07-12 16:03:59" = data$pasta,
+            "2016-07-12 15:59:25-2016-07-27 20:12:08" = data$pasta,
             "2016-07-12 16:03:59-2016-10-05 15:30:02" = data$pasta,
+            "2016-07-27 20:12:08-2017-05-23 12:31:34" = data$pasta,
             "2016-10-05 15:30:02-2017-05-23 12:32:40" = data$pasta
         )
     )
@@ -920,7 +981,7 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
 
     ## split data
     results = split.data.activity.based(project.data, activity.amount = nrow(data$issues) + 10,
-                                        activity.type = "issues", sliding.window = FALSE)
+                                        activity.type = "issues", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
@@ -957,12 +1018,12 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
     expect_equal(results.data, expected.data, info = "Data for ranges (too-large activity amount).")
 
     ##
-    ## split by number of windows
+    ## split by number of windows (i.e., ignoring sliding windows)
     ##
 
     ## split data
     results = split.data.activity.based(project.data, number.windows = 2,
-                                        activity.type = "issues", sliding.window = FALSE)
+                                        activity.type = "issues", sliding.window = TRUE)
 
     ## check time ranges
     expected = c(
@@ -1004,15 +1065,16 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
     )
     expect_equal(results.data, expected.data, info = "Data for ranges (number.windows).")
 
-    ## too large number of windows
+    ## too large number of windows (i.e., ignoring sliding windows)
 
     expect_error(
-        split.data.activity.based(project.data, activity.type = "issues", number.windows = nrow(project.data$get.issues()) + 10),
+        split.data.activity.based(project.data, activity.type = "issues",
+                                  number.windows = nrow(project.data$get.issues()) + 10, sliding.window = TRUE),
         info = "Error expected (number.windows) (1)."
     )
 
     expect_error(
-        split.data.activity.based(project.data, activity.type = "issues", number.windows = 0),
+        split.data.activity.based(project.data, activity.type = "issues", number.windows = 0, sliding.window = TRUE),
         info = "Error expected (number.windows) (2)."
     )
 })
@@ -1026,10 +1088,10 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
 ## * * time period ---------------------------------------------------------
 
 ##
-## Tests for split.network.time.based(..., time.period = ...)
+## Tests for split.network.time.based(..., time.period = ...) using sliding windows
 ##
 
-test_that("Split a network time-based (time.period = ...).", {
+test_that("Split a network time-based (time.period = ... , sliding.window = TRUE).", {
 
     ## time period
     time.period = "2 mins"
@@ -1051,11 +1113,14 @@ test_that("Split a network time-based (time.period = ...).", {
 
     expected = list(
         "2016-07-12 15:58:59-2016-07-12 16:00:59" = igraph::subgraph.edges(author.net, c(1:2)),
+        "2016-07-12 15:59:59-2016-07-12 16:01:59" = igraph::subgraph.edges(author.net, c(2)),
         "2016-07-12 16:00:59-2016-07-12 16:02:59" = igraph::subgraph.edges(author.net, c()),
+        "2016-07-12 16:01:59-2016-07-12 16:03:59" = igraph::subgraph.edges(author.net, c()),
         "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph.edges(author.net, c()),
+        "2016-07-12 16:03:59-2016-07-12 16:05:59" = igraph::subgraph.edges(author.net, c(3,5)),
         "2016-07-12 16:04:59-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(3:8))
     )
-    results = split.network.time.based(author.net, time.period = "2 mins")
+    results = split.network.time.based(author.net, time.period = "2 mins", sliding.window = TRUE)
 
     ## check ranges (labels)
     expect_equal(names(results), names(expected), info = "Time ranges.")
@@ -1077,158 +1142,17 @@ test_that("Split a network time-based (time.period = ...).", {
     ## retrieve author network
     author.net = net.builder$get.author.network()
 
-    expect_error(split.network.time.based(author.net, bins = bins), info = "Illegal split.")
+    expect_error(split.network.time.based(author.net, bins = bins, sliding.window = TRUE), info = "Illegal split.")
 
-})
-
-##
-## Tests for split.networks.time.based(..., time.period = ...)
-##
-
-test_that("Split a list of networks time-based.", {
-
-    ## time period
-    time.period = "2 years"
-
-    ## configuration and data objects
-    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
-    proj.conf$update.value("commits.filter.base.artifact", FALSE)
-    net.conf = NetworkConf$new()
-    net.conf$update.values(list(simplify = FALSE, author.directed = TRUE))
-    project.data = ProjectData$new(proj.conf)
-    net.builder = NetworkBuilder$new(project.data, net.conf)
-
-    ## obtain networks:
-    ## 1) co-change network
-    net.builder$update.network.conf(list(author.relation = "cochange"))
-    net.cochange = net.builder$get.author.network()
-    ## 2) mail network
-    net.builder$update.network.conf(list(author.relation = "mail"))
-    net.mail = net.builder$get.author.network()
-
-    ## split networks
-    net.split = split.networks.time.based(
-        networks = list(net.cochange, net.mail),
-        time.period = time.period,
-        sliding.window = FALSE
-    )
-
-    ## check whether the splitting information of the two split networks are identical
-    expect_identical(attributes(net.split[[1]]), attributes(net.split[[2]]), info = "Splitting information.")
-
-    ## check whether this works also with one network in the list (if not, an error will occur)
-    net.split = split.networks.time.based(
-        networks = list(net.mail),
-        time.period = time.period,
-        sliding.window = FALSE
-    )
-
-})
-
-## * * bins ----------------------------------------------------------------
-
-##
-## Tests for split.network.time.based(..., bins = ...)
-##
-
-test_that("Split a network time-based (bins = ...).", {
-
-    ## bins
-    bins = c("2016-07-12 15:58:00", "2016-07-12 16:00:59", "2016-07-12 16:02:59",
-             "2016-07-12 16:04:59", "2016-07-12 17:21:43")
-
-    ## configuration and data objects
-    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
-    proj.conf$update.value("commits.filter.base.artifact", FALSE)
-    net.conf = NetworkConf$new()
-    net.conf$update.values(list(author.relation = "cochange", simplify = FALSE))
-    project.data = ProjectData$new(proj.conf)
-    net.builder = NetworkBuilder$new(project.data, net.conf)
-
-    ##
-    ## simplify = FALSE
-    ##
-
-    ## retrieve author network
-    author.net = net.builder$get.author.network()
-
-    ## results
-    expected = list(
-        "2016-07-12 15:58:00-2016-07-12 16:00:59" = igraph::subgraph.edges(author.net, c(1:2)),
-        "2016-07-12 16:00:59-2016-07-12 16:02:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:04:59-2016-07-12 17:21:43" = igraph::subgraph.edges(author.net, c(3:8))
-    )
-    results = split.network.time.based(author.net, bins = bins)
-
-    ## check ranges (labels)
-    expect_equal(names(results), names(expected), info = "Time ranges.")
-
-    ## check networks
-    check.identical = mapply(results, expected, FUN = function(r, e) {
-        igraph::identical_graphs(r, e)
-    })
-    expect_true(all(check.identical), info = "Network equality.")
-
-    ##
-    ## simplify = TRUE
-    ##
-
-    ## update network configuration
-    net.conf$update.values(list(author.relation = "cochange", simplify = TRUE))
-    net.builder$reset.environment()
-
-    ## retrieve author network
-    author.net = net.builder$get.author.network()
-
-    expect_error(split.network.time.based(author.net, bins = bins), info = "Illegal split.")
-
-})
-
-## * * ranges --------------------------------------------------------------------
-
-##
-## Test splitting network by ranges.
-##
-
-test_that("Test splitting network by ranges", {
-
-
-    ## bins
-    bins = c("2016-07-12 15:58:00", "2016-07-12 16:00:59", "2016-07-12 16:02:59",
-             "2016-07-12 16:04:59", "2016-07-12 17:21:43")
-    ranges = construct.ranges(bins, sliding.window = FALSE, raw = TRUE)
-
-    ## configuration and data objects
-    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
-    proj.conf$update.value("commits.filter.base.artifact", FALSE)
-    net.conf = NetworkConf$new()
-    net.conf$update.values(list(author.relation = "cochange", simplify = FALSE))
-    project.data = ProjectData$new(proj.conf)
-    net.builder = NetworkBuilder$new(project.data, net.conf)
-
-    ## retrieve author network
-    author.net = net.builder$get.author.network()
-    expected.results = split.network.time.based(author.net, bins = bins)
-    results = split.network.time.based.by.ranges(author.net, ranges)
-
-    ## check time ranges
-    expect_equal(names(results), names(ranges), info = "Time ranges.")
-
-    ## check data for all ranges
-    check.identical = mapply(results, expected.results, FUN = function(r, e) {
-        return(igraph::identical_graphs(r, e))
-    })
-    expect_true(all(check.identical), info = "Network equality (split by ranges).")
 })
 
 ## * activity-based ------------------------------------------------------------
 
 ##
-## Tests for split.network.activity.based(...)
+## Tests for split.network.activity.based(...) using sliding windows
 ##
 
-test_that("Split a network activity-based (number.edges, number.windows).", {
+test_that("Split a network activity-based (number.edges, number.windows, sliding.window = TRUE).", {
 
     ## configuration and data objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -1248,11 +1172,14 @@ test_that("Split a network activity-based (number.edges, number.windows).", {
     ## results
     expected = list(
         "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(1, 2)),
+        "2016-07-12 16:00:45-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(2, 3)),
         "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(3, 5)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(5, 4)),
         "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(4, 7)),
+        "2016-07-12 16:06:10-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(7, 6)),
         "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(6, 8))
     )
-    results = split.network.activity.based(author.net, number.edges = 2)
+    results = split.network.activity.based(author.net, number.edges = 2, sliding.window = TRUE)
 
     ## check ranges (labels)
     expect_equal(names(results), names(expected), info = "Time ranges (number.edges (1)).")
@@ -1271,7 +1198,8 @@ test_that("Split a network activity-based (number.edges, number.windows).", {
     expected = list(
         "2016-07-12 15:58:59-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(1:igraph::ecount(author.net)))
     )
-    results = split.network.activity.based(author.net, number.edges = igraph::ecount(author.net) + 10)
+    results = split.network.activity.based(author.net, number.edges = igraph::ecount(author.net) + 10,
+                                           sliding.window = TRUE)
 
     ## check ranges (labels)
     expect_equal(names(results), names(expected), info = "Time ranges (number.edges (2)).")
@@ -1283,7 +1211,7 @@ test_that("Split a network activity-based (number.edges, number.windows).", {
     expect_true(all(check.identical), info = "Network equality (number.edges (2)).")
 
     ##
-    ## number.windows (1)
+    ## number.windows (1) (i.e., ignoring sliding windows)
     ##
 
     ## results
@@ -1292,7 +1220,7 @@ test_that("Split a network activity-based (number.edges, number.windows).", {
         "2016-07-12 16:05:41-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(4, 5, 7)),
         "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(6, 8))
     )
-    results = split.network.activity.based(author.net, number.windows = 3)
+    results = split.network.activity.based(author.net, number.windows = 3, sliding.window = TRUE)
 
     ## check ranges (labels)
     expect_equal(names(results), names(expected), info = "Time ranges (number.windows (1)).")
@@ -1304,386 +1232,56 @@ test_that("Split a network activity-based (number.edges, number.windows).", {
     expect_true(all(check.identical), info = "Network equality (number.windows (1)).")
 
     ##
-    ## number.windows (2)
+    ## number.windows (2) (i.e., ignoring sliding windows)
     ##
 
     expect_error(
-        split.network.activity.based(author.net, number.windows = igraph::ecount(author.net) + 10),
+        split.network.activity.based(author.net, number.windows = igraph::ecount(author.net) + 10,
+                                     sliding.window = TRUE),
         info = "Error expected (number.windows (2))."
     )
 
 })
 
-
-## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
-## Split raw data (data and networks by bins) ------------------------------
-
-##
-## Tests for split.data.by.bins and split.network.by.bins
-##
-
-test_that("Split network and data on low level (split.data.by.bins, split.network.by.bins).", {
-
-    length.dates = 15
-    length.bins = 5
-
-    ## generate dates
-    dates = c("2000-01-25", "2000-01-23", "2000-01-15", "2000-01-27", "2000-01-13",
-              "2000-01-03", "2000-01-05", "2000-01-29", "2000-01-19", "2000-01-01",
-              "2000-01-11", "2000-01-07", "2000-01-21", "2000-01-09", "2000-01-17")
-    # ## ## generated with:
-    # sprintf("c(\"%s\")", paste(
-    #     get.date.string(sample(
-    #         seq.POSIXt(get.date.from.string("2000-01-01"), get.date.from.string("2000-02-01"), by = "1 days"),
-    #         length.dates,
-    #         replace = FALSE
-    #     )), collapse = "\", \""))
-
-    ## generate bins
-    bins = seq_len(length.bins)
-    bins.vector = c("1", "3", "5", "4", "1", "3", "1", "3", "2", "5", "4", "2", "4", "3", "5")
-    ## ## generated with:
-    ## sprintf("c(\"%s\")", paste( sample(bins, size = length.dates, replace = TRUE), collapse = "', '") )
-
-    ##
-    ## split.data.by.bins
-    ##
-
-    ## generate data frame with dates and IDs
-    df = data.frame(
-        id = 1:length.dates,
-        date = dates
-    )
-
-    ## results
-    expected = list(
-        "1" = df[ c(1,  5,  7), ],
-        "2" = df[ c(9, 12), ],
-        "3" = df[ c(2,  6,  8, 14), ],
-        "4" = df[ c(4, 11, 13), ],
-        "5" = df[ c(3, 10, 15), ]
-    )
-    results = split.data.by.bins(df, bins.vector)
-
-    ## check result
-    expect_equal(results, expected, info = "Split data by bins.")
-
-    ##
-    ## split.network.by.bins
-    ##
-
-    ## generate data frame with dates and IDs
-    vcount = 4
-    net = igraph::make_empty_graph(n = vcount, directed = FALSE)
-    for (e.id in seq_len(length.dates)) {
-        net = net + igraph::edge(
-            sample(seq_len(vcount), 1), # from vertex
-            sample(seq_len(vcount), 1), # to vertex
-            date = get.date.from.string(dates[e.id])
-            )
-    }
-
-    ## results
-    expected = list(
-        igraph::subgraph.edges(net, c(1,  5,  7)),
-        igraph::subgraph.edges(net, c(9, 12)),
-        igraph::subgraph.edges(net, c(2,  6,  8, 14)),
-        igraph::subgraph.edges(net, c(4, 11, 13)),
-        igraph::subgraph.edges(net, c(3, 10, 15))
-    )
-    results = split.network.by.bins(net, bins, bins.vector)
-
-    ## check networks
-    check.identical = mapply(results, expected, FUN = function(r, e) {
-        igraph::identical_graphs(r, e)
-    })
-    expect_true(all(check.identical), info = "Split network by bins (network equality).")
-
-})
-
-
-## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
-## Bin identification ------------------------------------------------------
-
-##
-## Tests for split.get.bins.time.based and split.get.bins.activity.based
-##
-
-test_that("Get bins for network and data on low level (split.get.bins.time.based, split.get.bins.activity.based).", {
-
-    length.dates = 15
-    length.bins = 5
-
-    ## generate dates
-    dates = c("2000-01-25", "2000-01-23", "2000-01-15", "2000-01-27", "2000-01-13",
-              "2000-01-03", "2000-01-05", "2000-01-29", "2000-01-19", "2000-01-01",
-              "2000-01-11", "2000-01-07", "2000-01-21", "2000-01-09", "2000-01-17")
-    dates.posixct = get.date.from.string(dates)
-    ## ## generated with:
-    ## sprintf("c(\"%s\")", paste(
-    ##     get.date.string(sample(
-    ##         seq.POSIXt(get.date.from.string("2000-01-01"), get.date.from.string("2000-02-01"), by = "1 days"),
-    ##         length.dates,
-    ##         replace = FALSE
-    ##     )), collapse = "\", \""))
-
-    ##
-    ## split.get.bins.time.based (1)
-    ##
-
-    ## results
-    expected.bins  = c("2000-01-01 00:00:00", "2000-01-11 00:00:00", "2000-01-21 00:00:00", "2000-01-29 00:00:01")
-    expected = list(
-        vector = factor(head(expected.bins, -1))[c(3, 3, 2, 3, 2,
-                                                   1, 1, 3, 2, 1,
-                                                   2, 1, 3, 1, 2)],
-        bins = expected.bins
-    )
-    results = split.get.bins.time.based(dates.posixct, "10 days")
-
-    ## check result
-    expect_equal(results, expected, info = "split.get.bins.time.based (1)")
-
-    ##
-    ## split.get.bins.time.based (2)
-    ##
-
-    ## results
-    expected.bins  = c("2000-01-01 00:00:00", "2000-01-29 00:00:01")
-    expected = list(
-        vector = factor(head(expected.bins, -1))[ rep(1, length.dates) ],
-        bins = expected.bins
-    )
-    results = split.get.bins.time.based(dates.posixct, "1 year")
-
-    ## check result
-    expect_equal(results, expected, info = "split.get.bins.time.based (2)")
-
-    ##
-    ## split.get.bins.time.based (3)
-    ##
-
-    ## results
-    dates.unround = get.date.from.string(c("2004-01-01 00:00:00", "2004-01-01 00:00:14", "2004-01-01 00:00:22"))
-    expected.bins = c("2004-01-01 00:00:00", "2004-01-01 00:00:05", "2004-01-01 00:00:10",
-                      "2004-01-01 00:00:15", "2004-01-01 00:00:20", "2004-01-01 00:00:23") # adding 4.2 seconds each
-    expected = list(
-        vector = factor(head(expected.bins, -1))[ c(1, 3, 5) ],
-        bins = expected.bins
-    )
-    results = split.get.bins.time.based(dates.unround, number.windows = length.bins)
-
-    ## check result
-    expect_equal(results, expected, info = "split.get.bins.time.based (3)")
-
-    ##
-    ## split.get.bins.activity.based (1)
-    ##
-
-    ## construct data.frame
-    df = data.frame(date = dates.posixct, id = seq_len(length.dates))
-    df = df[ order(df$date), ]
-
-    ## results
-    expected = list(
-        vector = c(1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4),
-        bins = c("2000-01-01 00:00:00", "2000-01-09 00:00:00", "2000-01-17 00:00:00", "2000-01-25 00:00:00", "2000-01-29 00:00:01")
-    )
-    results = split.get.bins.activity.based(df, "id", 4)
-
-    ## check result
-    expect_equal(results, expected, info = "split.get.bins.activity.based (1)")
-
-    ##
-    ## split.get.bins.activity.based (2)
-    ##
-
-    ## construct data.frame
-    df = data.frame(date = dates.posixct, id = seq_len(length.dates))
-    df = df[ order(df$date), ]
-
-    ## results
-    expected = list(
-        vector = rep(1, length.out = length.dates),
-        bins = c("2000-01-01 00:00:00", "2000-01-29 00:00:01")
-    )
-    results = split.get.bins.activity.based(df, "id", nrow(df) + 10)
-
-    ## check result
-    expect_equal(results, expected, info = "split.get.bins.activity.based (2)")
-
-})
-
-
-## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
-## Consistency tests -------------------------------------------------------
-
-##
-## Tests for consistency of data and network time-based splitting
-##
-
-test_that("Check consistency of data and network time-based splitting.", {
+test_that("Split a network activity-based (number.edges, number.windows, sliding.window = TRUE), continued.", {
 
     ## configuration and data objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
     proj.conf$update.value("commits.filter.base.artifact", FALSE)
     net.conf = NetworkConf$new()
     net.conf$update.values(list(author.relation = "cochange", simplify = FALSE))
-
-    ## retrieve project data and network builder
     project.data = ProjectData$new(proj.conf)
     net.builder = NetworkBuilder$new(project.data, net.conf)
-    ## retrieve author network
-    project.net = net.builder$get.author.network()
 
-    ## set time period for splitting
-    time.period = "7 mins"
+    ## retrieve author network and add an additional edge in the end
+    author.net = net.builder$get.author.network()
+    author.net = igraph::add_edges(author.net, c("Olaf", "Thomas"),
+                                   attr = list(date = get.date.from.string("2020-02-20 20:20:20")))
 
-    ## split data
-    results.data = split.data.time.based(project.data, time.period = time.period, split.basis = "commits")
-    results.data.network = lapply(results.data, function(d) NetworkBuilder$new(d, net.conf)$get.author.network())
+    ##
+    ## number.edges (1)
+    ##
 
-    ## split network
-    results.network = split.network.time.based(project.net, time.period = time.period)
+    ## results
+    expected = list(
+        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(1, 2)),
+        "2016-07-12 16:00:45-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(2, 3)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(3, 5)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(5, 4)),
+        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(4, 7)),
+        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(7, 6)),
+        "2016-07-12 16:06:32-2020-02-20 20:20:20" = igraph::subgraph.edges(author.net, c(6, 8)),
+        "2016-07-12 16:06:32-2020-02-20 20:20:21" = igraph::subgraph.edges(author.net, c(8, 9))
+    )
+    results = split.network.activity.based(author.net, number.edges = 2, sliding.window = TRUE)
 
-    ## check ranges
-    expect_equal(names(results.network), names(results.data.network), info = "Range equality.")
+    ## check ranges (labels)
+    expect_equal(names(results), names(expected), info = "Time ranges (number.edges (1)).")
 
-    ## the chosen time-window size results in the following condition:
-    ## 1) Thomas and Karl only appear in the second time window, both working on the base feature.
-    ## 2) Olaf only appears in the first time window, working on the base feature as the only author.
-    ## Thus, when splitting the project-level network, there are edges from Olaf to Karl and Thomas,
-    ## crossing the time-window border. Hence, when deleting the respective vertices from the networks,
-    ## the data-based networks should match the network-based networks.
-    results.network[[1]] = igraph::delete.vertices(results.network[[1]], c("Thomas", "Karl"))
-    results.network[[2]] = igraph::delete.vertices(results.network[[2]], c("Olaf"))
-    check.identical = mapply(results.data.network, results.network, FUN = function(d, n) {
-        igraph::identical_graphs(d, n)
+    ## check networks
+    check.identical = mapply(results, expected, FUN = function(r, e) {
+        igraph::identical_graphs(r, e)
     })
-    expect_true(all(check.identical), info = "Network equality.")
-
-})
-
-
-## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
-## Unification of range names ----------------------------------------------
-
-##
-## Tests for duplicate range names
-##
-
-test_that("Check and correct duplicate range names during network activity-based splitting.", {
-
-    ## define dates for edges and the resulting changes
-    dates = get.date.from.string(c(
-        "2000-01-01 01:00:00", "2001-01-01 12:00:00",
-
-        "2001-01-01 12:00:00", "2001-01-01 12:00:00",
-        "2001-01-01 12:00:00", "2001-01-01 12:00:00",
-        "2001-01-01 12:00:00", "2001-01-01 12:00:00",
-
-        "2002-01-01 12:00:00", "2002-01-01 12:00:00",
-        "2002-01-01 12:00:00", "2002-01-01 12:00:00",
-        "2002-01-01 12:00:00", "2002-01-01 12:00:00",
-        "2002-01-01 12:00:00", "2002-01-01 12:00:00",
-
-        "2002-01-01 12:00:00", "2003-01-01 12:00:00"
-    ))
-    expected.ranges = c(
-        "2000-01-01 01:00:00-2001-01-01 12:00:00",
-
-        "2001-01-01 12:00:00-2001-01-01 12:00:00",
-        "2001-01-01 12:00:00-2001-01-01 12:00:00",
-
-        "2001-01-01 12:00:00-2002-01-01 12:00:00",
-
-        "2002-01-01 12:00:00-2002-01-01 12:00:00",
-        "2002-01-01 12:00:00-2002-01-01 12:00:00",
-        "2002-01-01 12:00:00-2002-01-01 12:00:00",
-        "2002-01-01 12:00:00-2002-01-01 12:00:00",
-
-        "2002-01-01 12:00:00-2003-01-01 12:00:01"
-    )
-    expected.ranges.corrected = c(
-        "2000-01-01 01:00:00-2001-01-01 12:00:00",
-
-        "2001-01-01 12:00:00-2001-01-01 12:00:00 (1)",
-        "2001-01-01 12:00:00-2001-01-01 12:00:00 (2)",
-
-        "2001-01-01 12:00:00-2002-01-01 12:00:00",
-
-        "2002-01-01 12:00:00-2002-01-01 12:00:00 (1)",
-        "2002-01-01 12:00:00-2002-01-01 12:00:00 (2)",
-        "2002-01-01 12:00:00-2002-01-01 12:00:00 (3)",
-        "2002-01-01 12:00:00-2002-01-01 12:00:00 (4)",
-
-        "2002-01-01 12:00:00-2003-01-01 12:00:01"
-    )
-
-    ## construct a small network
-    net = igraph::make_empty_graph(directed = FALSE) +
-        igraph::vertices(c("A", "B")) +
-        igraph::edges(rep(c("A", "B"), times = length(dates)))
-    ## set some date attributes that are appropriate for the test case
-    net = igraph::set.edge.attribute(net, "date", value = dates)
-
-    ## define split arguments
-    split.function = split.network.activity.based
-    split.activity.amount = 2
-    split.arguments = list(network = net, number.edges = split.activity.amount, sliding.window = FALSE)
-
-    ## check for issued warning
-    expect_output(
-        do.call(split.function, split.arguments),
-        "WARNING::Due to the splitting, there are duplicated range names.",
-        fixed = TRUE,
-        info = "Generate warning."
-    )
-
-    ## check range names
-    net.split = do.call(split.function, split.arguments)
-    ranges = names(net.split)
-    expect_equal(ranges, expected.ranges, info = "Ranges (original).")
-
-    ## correct ranges
-    ranges.corrected = split.unify.range.names(ranges)
-    expect_equal(ranges.corrected, expected.ranges.corrected, info = "Ranges (unified).")
-
-
-    ## Arbitrary range names (1)
-    ranges = c("A-B", "B-C", "C-D")
-    expected = c("A-B", "B-C", "C-D")
-    result = split.unify.range.names(ranges)
-    expect_identical(result, expected, info = "Arbitrary ranges (1).")
-
-    ## Arbitrary range names (2)
-    ranges = c("A-B", "A-B", "B-C", "B-C", "C-D")
-    expected = c("A-B (1)", "A-B (2)", "B-C (1)", "B-C (2)", "C-D")
-    result = split.unify.range.names(ranges)
-    expect_identical(result, expected, info = "Arbitrary ranges (2).")
-
-    ## Arbitrary range names (3)
-    ranges = c("A-B", "A-B", "B-C", "A-B", "B-C")
-    expected = c("A-B (1)", "A-B (2)", "B-C (1)", "A-B (1)", "B-C (1)")
-    result = split.unify.range.names(ranges)
-    expect_identical(result, expected, info = "Arbitrary ranges (3).")
-
-    ## Arbitrary range names (4)
-    ranges = c("A-B", "A-B", "B-C", "C-D", "C-D")
-    expected = c("A-B (1)", "A-B (2)", "B-C", "C-D (1)", "C-D (2)")
-    result = split.unify.range.names(ranges)
-    expect_identical(result, expected, info = "Arbitrary ranges (4).")
-
-    ##
-    ## the removal duplicate ranges
-    ##
-
-    df = data.frame(date = dates, id = 1:length(dates))
-    expected = expected.ranges[c(1, 4, 9)]
-    result = construct.ranges(
-        split.get.bins.activity.based(df, "id", activity.amount = split.activity.amount, remove.duplicate.bins = TRUE)[["bins"]],
-        sliding.window = FALSE
-    )
-    expect_identical(result, expected, info = "Removal of duplicate ranges.")
+    expect_true(all(check.identical), info = "Network equality (number.edges (1)).")
 
 })

--- a/tests/test-split-sliding-window.R
+++ b/tests/test-split-sliding-window.R
@@ -55,7 +55,7 @@ if (!dir.exists(CF.DATA)) CF.DATA = file.path(".", "tests", "codeface-data")
 ## Tests for split.data.time.based(..., split.basis = 'commits'), using sliding windows
 ##
 
-test_that("Split a data object time-based (split.basis == 'commits', sliding.window = TRUE).", {
+test_that("Split a data object time-based (split.basis = 'commits', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -142,7 +142,7 @@ test_that("Split a data object time-based (split.basis == 'commits', sliding.win
 ## Tests for split.data.time.based(..., split.basis = 'mails'), using sliding windows
 ##
 
-test_that("Split a data object time-based (split.basis == 'mails', sliding.window = TRUE).", {
+test_that("Split a data object time-based (split.basis = 'mails', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -241,7 +241,7 @@ test_that("Split a data object time-based (split.basis == 'mails', sliding.windo
 ## Tests for split.data.time.based(..., split.basis = 'issues'), using sliding windows
 ##
 
-test_that("Split a data object time-based (split.basis == 'issues', sliding.window = TRUE).", {
+test_that("Split a data object time-based (split.basis = 'issues', sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -323,7 +323,7 @@ test_that("Split a data object time-based (split.basis == 'issues', sliding.wind
 ## Tests for split.data.time.based(..., bins = ...), sliding windows parameter ignored
 ##
 
-test_that("Split a data object time-based (bins == ... , sliding.window = TRUE).", {
+test_that("Split a data object time-based (bins = ... , sliding.window = TRUE).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)

--- a/tests/test-split.R
+++ b/tests/test-split.R
@@ -14,6 +14,7 @@
 ## Copyright 2017-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
@@ -1085,7 +1086,7 @@ test_that("Split a network time-based (time.period = ...).", {
 ## Tests for split.networks.time.based(..., time.period = ...)
 ##
 
-test_that("Split a list of networks time-based.", {
+patrick::with_parameters_test_that("Split a list of networks time-based, ", {
 
     ## time period
     time.period = "2 years"
@@ -1110,7 +1111,7 @@ test_that("Split a list of networks time-based.", {
     net.split = split.networks.time.based(
         networks = list(net.cochange, net.mail),
         time.period = time.period,
-        sliding.window = FALSE
+        sliding.window = test.sliding.window
     )
 
     ## check whether the splitting information of the two split networks are identical
@@ -1120,10 +1121,13 @@ test_that("Split a list of networks time-based.", {
     net.split = split.networks.time.based(
         networks = list(net.mail),
         time.period = time.period,
-        sliding.window = FALSE
+        sliding.window = test.sliding.window
     )
 
-})
+}, patrick::cases(
+    "sliding window: FALSE" = list(test.sliding.window = FALSE),
+    "sliding window: TRUE" = list(test.sliding.window = TRUE)
+))
 
 ## * * bins ----------------------------------------------------------------
 
@@ -1131,7 +1135,7 @@ test_that("Split a list of networks time-based.", {
 ## Tests for split.network.time.based(..., bins = ...)
 ##
 
-test_that("Split a network time-based (bins = ...).", {
+patrick::with_parameters_test_that("Split a network time-based (bins = ...), ", {
 
     ## bins
     bins = c("2016-07-12 15:58:00", "2016-07-12 16:00:59", "2016-07-12 16:02:59",
@@ -1159,7 +1163,7 @@ test_that("Split a network time-based (bins = ...).", {
         "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph.edges(author.net, c()),
         "2016-07-12 16:04:59-2016-07-12 17:21:43" = igraph::subgraph.edges(author.net, c(3:8))
     )
-    results = split.network.time.based(author.net, bins = bins)
+    results = split.network.time.based(author.net, bins = bins, sliding.window = test.sliding.window)
 
     ## check ranges (labels)
     expect_equal(names(results), names(expected), info = "Time ranges.")
@@ -1181,9 +1185,13 @@ test_that("Split a network time-based (bins = ...).", {
     ## retrieve author network
     author.net = net.builder$get.author.network()
 
-    expect_error(split.network.time.based(author.net, bins = bins), info = "Illegal split.")
+    expect_error(split.network.time.based(author.net, bins = bins, sliding.window = test.sliding.window),
+                 info = "Illegal split.")
 
-})
+}, patrick::cases(
+    "sliding window (ignored): FALSE" = list(test.sliding.window = FALSE),
+    "sliding window (ignored): TRUE" = list(test.sliding.window = TRUE)
+))
 
 ## * * ranges --------------------------------------------------------------------
 

--- a/tests/test-split.R
+++ b/tests/test-split.R
@@ -62,7 +62,7 @@ if (!dir.exists(CF.DATA)) CF.DATA = file.path(".", "tests", "codeface-data")
 ## Tests for split.data.time.based(..., split.basis = 'commits')
 ##
 
-test_that("Split a data object time-based (split.basis == 'commits').", {
+test_that("Split a data object time-based (split.basis = 'commits').", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -137,7 +137,7 @@ test_that("Split a data object time-based (split.basis == 'commits').", {
 ## Tests for split.data.time.based(..., split.basis = 'mails')
 ##
 
-test_that("Split a data object time-based (split.basis == 'mails').", {
+test_that("Split a data object time-based (split.basis = 'mails').", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -219,7 +219,7 @@ test_that("Split a data object time-based (split.basis == 'mails').", {
 ## Tests for split.data.time.based(..., split.basis = 'issues')
 ##
 
-test_that("Split a data object time-based (split.basis == 'issues').", {
+test_that("Split a data object time-based (split.basis = 'issues').", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -296,7 +296,7 @@ test_that("Split a data object time-based (split.basis == 'issues').", {
 ## Tests for split.data.time.based(..., bins = ...)
 ##
 
-test_that("Split a data object time-based (bins == ... ).", {
+test_that("Split a data object time-based (bins = ... ).", {
 
     ## configuration objects
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)

--- a/util-data.R
+++ b/util-data.R
@@ -13,6 +13,7 @@
 ##
 ## Copyright 2016-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs-uni-saarland.de>
 ## Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 ## Copyright 2017-2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
@@ -1146,7 +1147,7 @@ ProjectData = R6::R6Class("ProjectData",
 
             ## get the timestamp data as vector
             timestamps.df = self$get.data.timestamps(data.sources = data.sources , simple = TRUE)
-            timestamps = c(start = timestamps.df[, "start"], end = timestamps.df[, "end"])
+            timestamps = c(start = timestamps.df[, "start"], end = timestamps.df[, "end"] + 1)
 
             ## check consistency
             if (timestamps["start"] > timestamps["end"]) {

--- a/util-misc.R
+++ b/util-misc.R
@@ -16,6 +16,7 @@
 ## Copyright 2017 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2017-2018 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018-2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## All Rights Reserved.
 
@@ -568,7 +569,10 @@ construct.overlapping.ranges = function(start, end, time.period, overlap, imperf
     ## compute negative overlap
     overlap.negative = time.period - overlap
     ## compute number of complete bins
-    bins.number = round(bins.duration / overlap.negative)
+    bins.number = floor(bins.duration / overlap.negative)
+    if (bins.number < 1) {
+        bins.number = 1
+    }
 
     ## generate a approximate sequence of dates which can be streamlined later
     seq.start = start.date + overlap

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -14,6 +14,7 @@
 ## Copyright 2016-2017 by Sofie Kemper <kemperso@fim.uni-passau.de>
 ## Copyright 2016-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2016-2018 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2017 by Angelika Schmid <schmidang@fim.uni-passau.de>
 ## Copyright 2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2019-2020 by Anselm Fehnker <anselm@muenster.de>
@@ -224,7 +225,7 @@ convert.adjacency.matrix.list.to.array = function(adjacency.list){
     colnames(array) = colnames(adjacency.list[[1]])
 
     ## copy the activity values from the adjacency matrices in the list to the corresponding array slices
-    for (i in seq_along(adjacency.ist)){
+    for (i in seq_along(adjacency.list)){
         adjacency = adjacency.list[[i]]
         activity.indices = which(adjacency != 0, arr.ind = TRUE)
 

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -11,8 +11,8 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
-## Copyright 2016 by Sofie Kemper <kemperso@fim.uni-passau.de>
-## Copyright 2016 by Claus Hunsen <hunsen@fim.uni-passau.de>
+## Copyright 2016-2017 by Sofie Kemper <kemperso@fim.uni-passau.de>
+## Copyright 2016-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2016-2018 by Thomas Bock <bockthom@fim.uni-passau.de>
 ## Copyright 2017 by Angelika Schmid <schmidang@fim.uni-passau.de>
 ## Copyright 2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>

--- a/util-plot.R
+++ b/util-plot.R
@@ -14,6 +14,7 @@
 ## Copyright 2017-2018 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 ## Copyright 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -129,7 +130,7 @@ plot.get.plot.for.network = function(network, labels = TRUE) {
     ## fix the type attributes (add new ones, also named)
     network = plot.fix.type.attributes(network)
 
-    ## set igraph network layout if not layout is set yet
+    ## set igraph network layout if no layout is set yet
     if (!("layout" %in% igraph::list.graph.attributes(network))) {
         network = igraph::set.graph.attribute(network, "layout", "kk")
     }

--- a/util-plot.R
+++ b/util-plot.R
@@ -46,11 +46,13 @@ PLOT.VERTEX.LABEL.COLOR = "gray60"
 
 #' Construct a ggplot2/ggraph plot object for the given network and print it directly.
 #'
-#' As a layout, by default, \code{igraph::layout.kamada.kawai} (also known as \code{igraph::layout_with_kk})
+#' As a layout, by default, the "kk" layout from igraph (also known as "layout_kamada_kawai") is used,
 #' is used, unless a graph attribute "layout" is set. For a comprehensive list of layouts and more information
-#' on layouts in general, see \link{http://igraph.org/r/doc/layout_.html}.
+#' on layouts in general, see \link{https://igraph.org/python/doc/tutorial/tutorial.html#layout-algorithms}.
 #' To set the graph attribute on your network, run the following code while replacing \code{layout.to.set}
 #' to your liking: \code{network = igraph::set.graph.attribute(network, "layout", layout.to.set)}.
+#' Note that \code{layout.to.set} refers to one of the "short names" of the recpective igraph layout, as
+#' specified on the Web site in the link given above.
 #'
 #' Note: The names for the vertex types are taken from the variables \code{PLOT.VERTEX.TYPE.AUTHOR} and
 #' \code{PLOT.VERTEX.TYPE.ARTIFACT}. The defaults are \code{"Developer"} and \code{TYPE.ARTIFACT}, respectively.
@@ -68,11 +70,13 @@ plot.network = function(network, labels = TRUE) {
 
 #' Construct a ggplot2/ggraph plot object for the given network and print it directly.
 #'
-#' As a layout, by default, \code{igraph::layout.kamada.kawai} (also known as \code{igraph::layout_with_kk})
+#' As a layout, by default, the "kk" layout from igraph (also known as "layout_kamada_kawai") is used,
 #' is used, unless a graph attribute "layout" is set. For a comprehensive list of layouts and more information
-#' on layouts in general, see \link{http://igraph.org/r/doc/layout_.html}.
+#' on layouts in general, see \link{https://igraph.org/python/doc/tutorial/tutorial.html#layout-algorithms}.
 #' To set the graph attribute on your network, run the following code while replacing \code{layout.to.set}
 #' to your liking: \code{network = igraph::set.graph.attribute(network, "layout", layout.to.set)}.
+#' Note that \code{layout.to.set} refers to one of the "short names" of the recpective igraph layout, as
+#' specified on the Web site in the link given above.
 #'
 #' Note: The names for the vertex types are taken from the variables \code{PLOT.VERTEX.TYPE.AUTHOR} and
 #' \code{PLOT.VERTEX.TYPE.ARTIFACT}. The defaults are \code{"Developer"} and \code{TYPE.ARTIFACT}, respectively.
@@ -91,11 +95,13 @@ plot.print.network = function(network, labels = TRUE) {
 
 #' Construct a ggplot2/ggraph plot object for the given network.
 #'
-#' As a layout, by default, \code{igraph::layout.kamada.kawai} (also known as \code{igraph::layout_with_kk})
+#' As a layout, by default, the "kk" layout from igraph (also known as "layout_kamada_kawai") is used,
 #' is used, unless a graph attribute "layout" is set. For a comprehensive list of layouts and more information
-#' on layouts in general, see \link{http://igraph.org/r/doc/layout_.html}.
+#' on layouts in general, see \link{https://igraph.org/python/doc/tutorial/tutorial.html#layout-algorithms}.
 #' To set the graph attribute on your network, run the following code while replacing \code{layout.to.set}
 #' to your liking: \code{network = igraph::set.graph.attribute(network, "layout", layout.to.set)}.
+#' Note that \code{layout.to.set} refers to one of the "short names" of the recpective igraph layout, as
+#' specified on the Web site in the link given above.
 #'
 #' Note: The names for the vertex types are taken from the variables \code{PLOT.VERTEX.TYPE.AUTHOR} and
 #' \code{PLOT.VERTEX.TYPE.ARTIFACT}. The defaults are \code{"Developer"} and \code{TYPE.ARTIFACT}, respectively.
@@ -123,13 +129,14 @@ plot.get.plot.for.network = function(network, labels = TRUE) {
     ## fix the type attributes (add new ones, also named)
     network = plot.fix.type.attributes(network)
 
-    ## set network layout
+    ## set igraph network layout if not layout is set yet
     if (!("layout" %in% igraph::list.graph.attributes(network))) {
-        network = igraph::set.graph.attribute(network, "layout", igraph::layout.kamada.kawai)
+        network = igraph::set.graph.attribute(network, "layout", "kk")
     }
+    layout.algorithm = igraph::get.graph.attribute(network, "layout")
 
-    ## create a ggraph object
-    p = ggraph::ggraph(network)
+    ## create a ggraph object using the specified igraph layout
+    p = ggraph::ggraph(network, layout = "igraph", algorithm = layout.algorithm)
 
     ## plot edges if there are any
     if (igraph::ecount(network) > 0) {

--- a/util-plot.R
+++ b/util-plot.R
@@ -137,7 +137,7 @@ plot.get.plot.for.network = function(network, labels = TRUE) {
     layout.algorithm = igraph::get.graph.attribute(network, "layout")
 
     ## create a ggraph object using the specified igraph layout
-    p = ggraph::ggraph(network, layout = "igraph", algorithm = layout.algorithm)
+    p = ggraph::ggraph(network, layout = layout.algorithm)
 
     ## plot edges if there are any
     if (igraph::ecount(network) > 0) {

--- a/util-split.R
+++ b/util-split.R
@@ -293,7 +293,7 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
     } else if (sliding.window) {
         ## get the list of unique items that are used for the bin computation and, thus, also the
         ## cropping of data
-        items.unique = unique(data[[ activity.type ]][[ id.column[[activity.type]] ]])
+        items.unique = unique(data[[activity.type]][[ id.column[[activity.type]] ]])
         items.unique.count = length(items.unique)
 
         ## offsets used for cropping (half the first/last bin)
@@ -311,12 +311,12 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
 
         ## determine end bin of last sliding-window range
         end.event.id = items.unique[(items.unique.count - offset.end + 1)]
-        end.event.logical = data[[ activity.type ]][[ id.column[[activity.type]] ]] == end.event.id
-        end.event.date = data[[ activity.type ]][end.event.logical, ][[ "date" ]]
+        end.event.logical = (data[[activity.type]][[ id.column[[activity.type]] ]] == end.event.id)
+        end.event.date = data[[activity.type]][end.event.logical, ][["date"]]
 
         ## store the data again
-        data.to.cut = data[[ activity.type ]][[ id.column[[activity.type]] ]] %in% items.cut
-        data[[ activity.type ]] = data[[ activity.type ]][ !data.to.cut, ]
+        data.to.cut = data[[activity.type]][[ id.column[[activity.type]] ]] %in% items.cut
+        data[[activity.type]] = data[[activity.type]][ !data.to.cut, ]
 
         ## clone the project data and update raw data to split it again
         project.data.clone = project.data$clone()
@@ -342,7 +342,7 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
         bins.date = sort(c(bins.date, bins.date.middle))
         bins = get.date.string(bins.date)
 
-        ## if last regular range and last sliding-window range end at the same time
+        ## if the last regular range and the last sliding-window range end at the same time
         ## and the data of the last regular range is contained in the last sliding-window range, then:
         ## remove the last regular range as it is not complete and we don't loose data when removing it
         last.regular.range = cf.data[[length(cf.data)]]
@@ -803,7 +803,7 @@ split.network.activity.based = function(network, number.edges = 5000, number.win
         ## construct proper bin vectors for configuration
         bins.date = sort(c(bins.date, bins.date.middle))
 
-        ## if last regular range and last sliding-window range end at the same time,
+        ## if the last regular range and the last sliding-window range end at the same time
         ## and the latter contains the former's edges, then:
         ## remove the last regular range as it is not complete and we don't loose data when removing it
         edges.last.regular = igraph::E(networks[[length(networks)]])

--- a/util-split.R
+++ b/util-split.R
@@ -40,7 +40,7 @@ requireNamespace("lubridate") # for date conversion
 #'
 #' @param project.data the *Data object from which the data is retrieved
 #' @param time.period the time period describing the length of the ranges, a character string,
-#'                    e.g., "3 mins" or "15 days"
+#'                    e.g., "3 mins" or "15 days" [default: "3 months"]
 #' @param bins the date objects defining the start of ranges (the last date defines the end of the last range, in an
 #'             *exclusive* manner). If set, the 'time.period' parameter is ignored; consequently, 'split.basis' and
 #'             'sliding.window' do not make sense then either. [default: NULL]
@@ -49,7 +49,7 @@ requireNamespace("lubridate") # for date conversion
 #'                       consequently, 'split.basis' and 'sliding.window' do not make sense then either.
 #'                       [default: NULL]
 #' @param split.basis the data name to use as the basis for split bins, either 'commits', 'mails', or 'issues'
-#'                    [default: commits]
+#'                    [default: "commits"]
 #' @param sliding.window logical indicating whether the splitting should be performed using a sliding-window approach
 #'                       [default: FALSE]
 #'
@@ -218,7 +218,7 @@ split.data.time.based = function(project.data, time.period = "3 months", bins = 
 #'
 #' @param project.data the *Data object from which the data is retrieved
 #' @param activity.type the type of activity used for splitting, either 'commits', 'mails', or 'issues'
-#'                      [default: commits]
+#'                      [default: "commits"]
 #' @param activity.amount the amount of activity describing the size of the ranges, a numeric, further
 #'                        specified by 'activity.type' [default: 5000]
 #' @param number.windows the number of consecutive data objects to get from this function
@@ -498,9 +498,10 @@ split.data.time.based.by.ranges = function(project.data, ranges) {
 #'
 #' @param network the igraph network to split, needs to have an edge attribute named "date"
 #' @param time.period the time period describing the length of the ranges, a character string,
-#'                    e.g., "3 mins" or "15 days"
+#'                    e.g., "3 mins" or "15 days" [default: "3 months"]
 #' @param bins the date objects defining the start of ranges (the last date defines the end of the last range, in an
 #'             *exclusive* manner). If set, the 'time.period' and 'sliding.window' parameters are ignored.
+#'             [default: NULL]
 #' @param number.windows the number of consecutive networks to get from this function, implying equally
 #'                       time-sized windows for all ranges. If set, the 'time.period' and 'bins' parameters are ignored;
 #'                       consequently, 'sliding.window' does not make sense then either.
@@ -584,9 +585,10 @@ split.network.time.based = function(network, time.period = "3 months", bins = NU
 #'
 #' @param networks the igraph networks to split, needs to have an edge attribute named "date"
 #' @param time.period the time period describing the length of the ranges, a character string,
-#'                    e.g., "3 mins" or "15 days"
+#'                    e.g., "3 mins" or "15 days" [default: "3 months"]
 #' @param bins the date objects defining the start of ranges (the last date defines the end of the last range, in an
 #'             *exclusive* manner). If set, the 'time.period' and 'sliding.window' parameters are ignored.
+#'             [default: NULL]
 #' @param number.windows the number of consecutive networks to get for each network, implying equally
 #'                       time-sized windows for all ranges. If set, the 'time.period' and 'bins' parameters are ignored;
 #'                       consequently, 'sliding.window' does not make sense then either.
@@ -600,7 +602,6 @@ split.network.time.based = function(network, time.period = "3 months", bins = NU
 split.networks.time.based = function(networks, time.period = "3 months", bins = NULL,
                                      number.windows = NULL, sliding.window = FALSE,
                                      remove.isolates = TRUE) {
-
 
     ## number of windows given (ignoring time period and bins)
     if (!is.null(number.windows)) {
@@ -669,7 +670,7 @@ split.networks.time.based = function(networks, time.period = "3 months", bins = 
 #'
 #' @param network the igraph network to split
 #' @param number.edges the amount of edges describing the size of the ranges
-#'                     (implying an open number of resulting ranges)
+#'                     (implying an open number of resulting ranges) [default: 5000]
 #' @param number.windows the number of consecutive networks to get from this function
 #'                       (implying an equally distributed amount of edges in each range and
 #'                       'sliding.window = FALSE) [default: NULL]

--- a/util-split.R
+++ b/util-split.R
@@ -842,7 +842,7 @@ split.data.by.bins = function(df, bins) {
 #'
 #' @return a list of networks, with the length of 'unique(bins.vector)'
 split.network.by.bins = function(network, bins, bins.vector, remove.isolates = TRUE) {
-    logging::logdebug("split.data.time.based: starting.")
+    logging::logdebug("split.network.by.bins: starting.")
     ## create a network for each bin of edges
     nets = parallel::mclapply(bins, function(bin) {
         logging::logdebug("Splitting network: bin %s", bin)
@@ -852,7 +852,7 @@ split.network.by.bins = function(network, bins, bins.vector, remove.isolates = T
         g = igraph::subgraph.edges(network, edges, delete.vertices = remove.isolates)
         return(g)
     })
-    logging::logdebug("split.data.time.based: finished.")
+    logging::logdebug("split.network.by.bins: finished.")
     return(nets)
 }
 


### PR DESCRIPTION
### Description

As already discussed in #182, when calling the function `split.networks.time.based` (which splits several networks at the same time), the `sliding.window` parameter was useless: This function, in turn, calls `split.network.time.based` for each network, specifying fixed bins and passing the 'sliding.window' parameter to it. However, if bins are given to this function, the `sliding.window` parameter is ignored.
While dealing with finding an appropriate solution for that problem, it turned out that the implementation of creating sliding windows also in all the other cases lead to inconsistent behavior, especially targeting the last and second last ranges created during splitting while using `sliding.window = TRUE`. Hence, this led to a lot of debugging work and implementing new fixes which are described below:

#### Fix sliding-window creation in various situations

For that reason, I completely reworked all the splitting functions with respect to their `sliding.window` creation approach to use the function `create.overlapping.ranges` everywhere (where applicable) and result in the same, reliable way of creating sliding-window ranges. I also included proper handling of the last range: In many cases, the last (incomplete) "original" range should be ignored when the last "sliding-window" ranges already covers this last "original" range completely. For brevity reasons, I won't provide further details in the PR description. However, I have split up all my changes into small commits and added detailed explanations and also detailed examples in the commit messages. So, for more details, please have a look at the respective commit messages :wink: (1abc1b8, c34c42a, 097cebc, 9a1b651, 0fc179e, cad28bf)

#### Add tests for sliding-window functionality (as we did not have tests for that before)

Another major contribution of this pull request is an extension of our test suite: Previously, there was no test covering sliding windows at all - not anywhere near touching sliding windows at all. As I completely reworked many parts of the splitting module with respect to sliding windows, I also added lots of tests to be sure my changes to the splitting functionality work the way I want them to work. I have added a new test module `test-split-sliding-window.R` (to not even extend the lengthy `test-split.R`). Most of the tests in there are copied from `test-split.R` and adjusted to use `sliding.window = TRUE`. As this is not enough to test as many situations where sliding windows can cause trouble as possible, I also adjusted some other splitting-related tests in the other test modules. And here another innovation comes in: As these splitting-related tests often cope without specifying a concrete expected result by hand, we can make use of parameterized tests (i.e., running the same test multiple times without any changes except for changing fixed parameters). Using parameterized tests, we can test several functions with `sliding.window = TRUE` and `sliding.window = FALSE` without copying the test code, which is a great innovation to our test suite (at least, from my point of view). Nevertheless, our standard test library `testthat` does not provide the possibility to run parameterized tests. Therefore, we now use the package [`patrick`](https://github.com/google/patrick) for parameterized tests, which itself builds on top of `testthat`. (a3ad0a8, 2ed84ac)

#### Further fixes (e.g., in data-cutting functionality)

Last but not least, this Pull Request also contains additional bug fixes, not directly related to the sliding-window problem:  The data cutting (performed via `get.data.cut.to.same.date`) actually behaves wrong with respect to the end date where to cut at, as it did not consider that end dates of ranges are exclusive, but the end date of the data cutting functionality was meant to be inclusive. Further details can also be seen in the example which is contained in the commit message of the corresponding commit (f0744c0). 

~~*[One important notice on this PR: This PR also includes the commits of PR #183 to be able to run travis builds in a reasonable way. Please ignore all commits related to Travis CI configuration R versions, as those will disappear from this PR as soon #183 will be merged. If you would like to discuss on them, please use the discussion of #183. This PR **must not** be merged until PR #183 is merged!]*~~

I hope you all are happy to get all those (or more precisely: many of those) issues and bugs fixed via this PR :balloon:
I look forward to your reviews :smile: 

<!-- Add a description of the added/changed/fixed functionality in this pull request. -->

### Changelog

Is still missing yet. Will be added here and also to the NEWS.md as soon as most of the parts of this PR are approved by someone else :wink: 

<!-- Put the updated/added parts of the changelog here. -->

### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](https://github.com/se-passau/coronet/blob/master/CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](https://github.com/se-passau/coronet/blob/master/NEWS.md) appropriately.
- [x] The pull request is opened against the branch `dev`.

