### PR TITLE
Fixes in the metrics module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,19 @@
 ### Added
 - Add functionality to read and process commit messages in order to merge them to the commit data (see issue #180). Three values are available for the new attribute `commit.messages` in `ProjectConf`: `none`, `title` and `messages` (PR #193, 85b1d0572c0fb9f4c062bceb1363b0398f98b85f, fdc414ade1a640f533e809a25cfe012e42b3cffa, 43e1894998e18faff3a65114fa65ee54e1d2f66e)
 - Add functions `cleanup.commit.message.data` and `cleanup.synchronicity.data` to remove commit hashes that are not any more present in the commit data from the commit message data or synchronicity data (PR #193, 98e83b037ecc88d9a29e8e4ca93598a9978e85a2)
+- Add function `metrics.is.smallworld` to the metrics module in order to unify checks for smallworldness (similar to scalefreeness) (PR #195, 597843db3dfd18e49deb28dde9ee99057003087d)
+- Add 'metrics.centrality' function to metrics module in order to simplify getting a data frame containing author names
+and their respective centrality values (3f41aa7af1c35947035ce7cf0e6c6edcec7a1cf8)
+- Add `get.data.sources.from.relations` to `util-networks.R` which extracts the data sources of a network that were used when building it (PR #195, 450a74d56a065f8e4a69ae28edb0b49ffd112652)
+- Add tests for the `get.data.sources.from.relations` function (PR #195, afbba88f85e7777828534611445e8463be4d55dc)
 
 ### Changed/Improved
 - Add `.drone.yml` to enable running our CI pipelines on drone.io (PR #191, 1c5804b59c582cf34af6970b435add51452fbd11)
+- Add more explanation to `metrics.avg.path.length` and as well as default values for that function (PR #195, 6bf6e4056692e5265a065c91da779355b3fbf66a)
+- Add default parameters to documentation of several other methods missing them (PR #195, 2085024661fcdc287a009cf6aa7f438cad7459ae)
+- Handle error in igraph function by printing user warning instead. When calling  `metrics.smallworldness` with a network that is too large, i.e. that has too many edges a warning is being printed and `NA` is returned (PR #195, 8489c055557aba9a21bec0c7704fc2e1176a3a2c)
+- Add check for empty network in `metrics.hub-degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 231affc5d1c201b0cc3ea093477afde6acd6b9a5)
+
 
 ## 3.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ and their respective centrality values (d3cd528609480f87658601ef13326e950a74cce7
 - Add `.drone.yml` to enable running our CI pipelines on drone.io (PR #191, 1c5804b59c582cf34af6970b435add51452fbd11)
 - Update documentation in `util-network-metrics.R` (PR #195, f929248, f929248182594613bd203e100268e3e3dce87f34, de9988cc171cafdd084701d5a2693a74176a802a)
 - Add check for empty network in `metrics.hub.degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 4b164bebea1e8258cb93febf51271a4b6f486779)
+- Adjust the function `ProjectData$get.artifacts`: Rename its single parameter to `data.sources` and change the function so that it can extract the artifacts for multiple data sources at once. The default is still that only artifacts from the commit data are extracted.
+
 
 ## 3.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,17 +5,16 @@
 ### Added
 - Add functionality to read and process commit messages in order to merge them to the commit data (see issue #180). Three values are available for the new attribute `commit.messages` in `ProjectConf`: `none`, `title` and `messages` (PR #193, 85b1d0572c0fb9f4c062bceb1363b0398f98b85f, fdc414ade1a640f533e809a25cfe012e42b3cffa, 43e1894998e18faff3a65114fa65ee54e1d2f66e)
 - Add functions `cleanup.commit.message.data` and `cleanup.synchronicity.data` to remove commit hashes that are not any more present in the commit data from the commit message data or synchronicity data (PR #193, 98e83b037ecc88d9a29e8e4ca93598a9978e85a2)
-- Add function `metrics.is.smallworld` to the metrics module in order to unify checks for smallworldness (similar to scalefreeness) (PR #195, 597843db3dfd18e49deb28dde9ee99057003087d)
+- Add function `metrics.is.smallworld` to the metrics module in order to unify checks for smallworldness (similar to scalefreeness) (PR #195, ce1f8124298d73830f3fd96aa84e82ba89181aa6)
 - Add `metrics.vertex.centralities` function to metrics module in order to simplify getting a data frame containing author names
-and their respective centrality values (3f41aa7af1c35947035ce7cf0e6c6edcec7a1cf8)
-- Add `get.data.sources.from.relations` to `util-networks.R` which extracts the data sources of a network that were used when building it (PR #195, 450a74d56a065f8e4a69ae28edb0b49ffd112652)
-- Add tests for the `get.data.sources.from.relations` function (PR #195, afbba88f85e7777828534611445e8463be4d55dc)
+and their respective centrality values (d3cd528609480f87658601ef13326e950a74cce7)
+- Add `get.data.sources.from.relations` to `util-networks.R` which extracts the data sources of a network that were used when building it (PR #195, d1e4413a49ab83a115a7f26719592876371ab264)
+- Add tests for the `get.data.sources.from.relations` function (PR #195, add0c746dde8279da41d180deecf52b91a46095c)
 
 ### Changed/Improved
 - Add `.drone.yml` to enable running our CI pipelines on drone.io (PR #191, 1c5804b59c582cf34af6970b435add51452fbd11)
-- Update documentation in `util-network-metrics.R` (PR #195, 2085024661fcdc287a009cf6aa7f438cad7459ae, 6bf6e4056692e5265a065c91da779355b3fbf66a)
-- Add check for empty network in `metrics.hub.degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 231affc5d1c201b0cc3ea093477afde6acd6b9a5)
-
+- Update documentation in `util-network-metrics.R` (PR #195, f929248, f929248182594613bd203e100268e3e3dce87f34, de9988cc171cafdd084701d5a2693a74176a802a)
+- Add check for empty network in `metrics.hub.degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 4b164bebea1e8258cb93febf51271a4b6f486779)
 
 ## 3.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 - Add functionality to read and process commit messages in order to merge them to the commit data (see issue #180). Three values are available for the new attribute `commit.messages` in `ProjectConf`: `none`, `title` and `messages` (PR #193, 85b1d0572c0fb9f4c062bceb1363b0398f98b85f, fdc414ade1a640f533e809a25cfe012e42b3cffa, 43e1894998e18faff3a65114fa65ee54e1d2f66e)
 - Add functions `cleanup.commit.message.data` and `cleanup.synchronicity.data` to remove commit hashes that are not any more present in the commit data from the commit message data or synchronicity data (PR #193, 98e83b037ecc88d9a29e8e4ca93598a9978e85a2)
 - Add function `metrics.is.smallworld` to the metrics module in order to unify checks for smallworldness (similar to scalefreeness) (PR #195, 597843db3dfd18e49deb28dde9ee99057003087d)
-- Add 'metrics.centrality' function to metrics module in order to simplify getting a data frame containing author names
+- Add `metrics.vertex.centralities` function to metrics module in order to simplify getting a data frame containing author names
 and their respective centrality values (3f41aa7af1c35947035ce7cf0e6c6edcec7a1cf8)
 - Add `get.data.sources.from.relations` to `util-networks.R` which extracts the data sources of a network that were used when building it (PR #195, 450a74d56a065f8e4a69ae28edb0b49ffd112652)
 - Add tests for the `get.data.sources.from.relations` function (PR #195, afbba88f85e7777828534611445e8463be4d55dc)
@@ -14,7 +14,7 @@ and their respective centrality values (3f41aa7af1c35947035ce7cf0e6c6edcec7a1cf8
 ### Changed/Improved
 - Add `.drone.yml` to enable running our CI pipelines on drone.io (PR #191, 1c5804b59c582cf34af6970b435add51452fbd11)
 - Update documentation in `util-network-metrics.R` (PR #195, 2085024661fcdc287a009cf6aa7f438cad7459ae, 6bf6e4056692e5265a065c91da779355b3fbf66a)
-- Add check for empty network in `metrics-hub-degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 231affc5d1c201b0cc3ea093477afde6acd6b9a5)
+- Add check for empty network in `metrics.hub.degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 231affc5d1c201b0cc3ea093477afde6acd6b9a5)
 
 
 ## 3.7

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,10 +13,8 @@ and their respective centrality values (3f41aa7af1c35947035ce7cf0e6c6edcec7a1cf8
 
 ### Changed/Improved
 - Add `.drone.yml` to enable running our CI pipelines on drone.io (PR #191, 1c5804b59c582cf34af6970b435add51452fbd11)
-- Add more explanation to `metrics.avg.path.length` and as well as default values for that function (PR #195, 6bf6e4056692e5265a065c91da779355b3fbf66a)
-- Add default parameters to documentation of several other methods missing them (PR #195, 2085024661fcdc287a009cf6aa7f438cad7459ae)
-- Handle error in igraph function by printing user warning instead. When calling  `metrics.smallworldness` with a network that is too large, i.e. that has too many edges a warning is being printed and `NA` is returned (PR #195, 8489c055557aba9a21bec0c7704fc2e1176a3a2c)
-- Add check for empty network in `metrics.hub-degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 231affc5d1c201b0cc3ea093477afde6acd6b9a5)
+- Update documentation in `util-network-metrics.R` (PR #195, 2085024661fcdc287a009cf6aa7f438cad7459ae, 6bf6e4056692e5265a065c91da779355b3fbf66a)
+- Add check for empty network in `metrics-hub-degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 231affc5d1c201b0cc3ea093477afde6acd6b9a5)
 
 
 ## 3.7

--- a/tests/test-networks.R
+++ b/tests/test-networks.R
@@ -12,6 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2018-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
+## Copyright 2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -695,4 +696,33 @@ test_that("Addition of edge attributes with data", {
         info = "multi network – issue/cochange"
     )
 
+})
+
+## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+## Extract data sources ----------------------------------------------------
+test_that("Get the data sources from a network with two relations", {
+    expected.relations = c("mails", "commits")
+    network = get.sample.network()
+
+    expect_identical(expected.relations, get.data.sources.from.relations(network), info = "data sources: mails, commits")
+})
+
+test_that("Get the data sources from a network with one relation", {
+    expected.relations = c("mails")
+
+    ## configurations
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.conf$update.value("commits.filter.base.artifact", FALSE)
+    ## construct data object
+    proj.data = ProjectData$new(project.conf = proj.conf)
+
+    ## construct network builder
+    net.conf = NetworkConf$new()
+    network.builder = NetworkBuilder$new(project.data = proj.data, network.conf = net.conf)
+    network.builder$update.network.conf(updated.values = list(author.relation = "mail"))
+
+    ## build network
+    network = network.builder$get.author.network()
+
+    expect_identical(expected.relations, get.data.sources.from.relations(network), info = "data sources: mails")
 })

--- a/tests/test-networks.R
+++ b/tests/test-networks.R
@@ -701,14 +701,14 @@ test_that("Addition of edge attributes with data", {
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
 ## Extract data sources ----------------------------------------------------
 test_that("Get the data sources from a network with two relations", {
-    expected.relations = c("mails", "commits")
+    expected.data.sources = c("mails", "commits")
     network = get.sample.network()
 
-    expect_identical(expected.relations, get.data.sources.from.relations(network), info = "data sources: mails, commits")
+    expect_identical(expected.data.sources, get.data.sources.from.relations(network), info = "data sources: mails, commits")
 })
 
 test_that("Get the data sources from a network with one relation", {
-    expected.relations = c("mails")
+    expected.data.sources = c("mails")
 
     ## configurations
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
@@ -724,5 +724,5 @@ test_that("Get the data sources from a network with one relation", {
     ## build network
     network = network.builder$get.author.network()
 
-    expect_identical(expected.relations, get.data.sources.from.relations(network), info = "data sources: mails")
+    expect_identical(expected.data.sources, get.data.sources.from.relations(network), info = "data sources: mails")
 })

--- a/util-core-peripheral.R
+++ b/util-core-peripheral.R
@@ -93,7 +93,7 @@ LONGTERM.CORE.THRESHOLD = 0.5
 #'
 #' @return the classification result, that is, a list containing two named list members \code{core} and
 #'         \code{peripheral}, each of which holding the authors classified as core or peripheral, respectively. Both
-#'         entries in this list (\code{core} and \code{peripheral) are dataframes containing the authors' names in the
+#'         entries in this list (\code{core} and \code{peripheral) are data frames containing the authors' names in the
 #'         first column and their centrality values in the second column.
 get.author.class.by.type = function(network = NULL,
                                     proj.data = NULL,
@@ -198,7 +198,7 @@ get.author.class.by.type = function(network = NULL,
         centrality.dataframe = get.author.loc.count(proj.data)
     }
 
-    # rename the second column of the centrality dataframe to the correct name with respect to the classification type
+    # rename the second column of the centrality data frame to the correct name with respect to the classification type
     names(centrality.dataframe)[2] = metric.name
 
     ## If the parameter 'restrict.classification.to.authors' is 'NULL', no restriction is made.

--- a/util-data.R
+++ b/util-data.R
@@ -1102,11 +1102,11 @@ ProjectData = R6::R6Class("ProjectData",
 
         #' Get the list of artifacts from the given \code{data.source} of the project.
         #'
-        #' @param data.source The specified data source. One of \code{"commits"},
-        #'                    \code{"mails"}, and \code{"issues"} or multiple of them. [default: "commits"]
+        #' @param data.sources The specified data source. One of \code{"commits"},
+        #'                     \code{"mails"}, and \code{"issues"} or multiple of them. [default: "commits"]
         #'
         #' @return the character vector of unique artifacts (can be empty)
-        get.artifacts = function(data.source = c("commits", "mails", "issues")) {
+        get.artifacts = function(data.sources = c("commits", "mails", "issues")) {
             logging::loginfo("Getting artifact data.")
 
             ## get the right value when nothing is passed for 'data.source'
@@ -1115,24 +1115,24 @@ ProjectData = R6::R6Class("ProjectData",
             ## behavior: if 'data.source' is missing, 'several.ok' will be 'FALSE' making the function return
             ## the first element of the choice vector. If an argument is present, 'several.ok' will be 'TRUE' allowing
             ## multiple values for the argument
-            data.source = match.arg(data.source, several.ok = !missing(data.source))
+            data.sources = match.arg(data.sources, several.ok = !missing(data.sources))
 
-            data.source.func = sapply(data.source, function(d) {
+            data.source.funcs = sapply(data.sources, function(d) {
                 return(DATASOURCE.TO.ARTIFACT.FUNCTION[[d]])
             }, USE.NAMES = FALSE)
 
-            data.source.col = sapply(data.source, function(d) {
+            data.source.cols = sapply(data.sources, function(d) {
                 return(DATASOURCE.TO.ARTIFACT.COLUMN[[d]])
             }, USE.NAMES = FALSE)
 
             ## get actual artifact data
-            data = lapply(data.source.func, function(d) {
+            data = lapply(data.source.funcs, function(d) {
                 return(self[[d]]())
             })
 
             artifacts = c()
             for (df in data) {
-                unique.artifacts = unique(df[[data.source.col]])
+                unique.artifacts = unique(df[[data.source.cols]])
                 artifacts = append(artifacts, unique.artifacts)
             }
 

--- a/util-data.R
+++ b/util-data.R
@@ -1109,7 +1109,23 @@ ProjectData = R6::R6Class("ProjectData",
         get.artifacts = function(data.source = c("commits", "mails", "issues")) {
             logging::loginfo("Getting artifact data.")
 
-            data.source = match.arg.or.default(data.source, several.ok = TRUE)
+            ## check whether the argument 'data.source' is missing and set the default manually because
+            ## the 'match.arg.or.default' function returns the whole vector when no argument is passed with 'several.ok'
+            ## set to 'TRUE'
+            if (missing(data.source)) {
+                ## get the arguments of the function calling 'formals', resulting in the arguments of this
+                ## 'get.artifacts' function, according to the documentation
+                formal.args = formals()
+                ## get the fixed default value of the argument 'data.source'
+                choices = eval(formal.args[[as.character(substitute(data.source))]])
+                ## set the value to its first element as this is the expected behavior
+                data.source = choices[[1]]
+            }
+            else {
+                ## if an argument is passed, use the match function to sort it out for us
+                data.source = match.arg.or.default(data.source, several.ok = TRUE)
+            }
+
             data.source.func = sapply(data.source, function(d) {
                 return(DATASOURCE.TO.ARTIFACT.FUNCTION[[d]])
             }, USE.NAMES = FALSE)

--- a/util-data.R
+++ b/util-data.R
@@ -1126,7 +1126,6 @@ ProjectData = R6::R6Class("ProjectData",
             artifacts = c()
             for (df in data) {
                 unique.artifacts = unique(df[[data.source.col]])
-                print(unique.artifacts)
                 artifacts = append(artifacts, unique.artifacts)
             }
 

--- a/util-data.R
+++ b/util-data.R
@@ -1109,22 +1109,13 @@ ProjectData = R6::R6Class("ProjectData",
         get.artifacts = function(data.source = c("commits", "mails", "issues")) {
             logging::loginfo("Getting artifact data.")
 
-            ## check whether the argument 'data.source' is missing and set the default manually because
-            ## the 'match.arg.or.default' function returns the whole vector when no argument is passed with 'several.ok'
-            ## set to 'TRUE'
-            if (missing(data.source)) {
-                ## get the arguments of the function calling 'formals', resulting in the arguments of this
-                ## 'get.artifacts' function, according to the documentation
-                formal.args = formals()
-                ## get the fixed default value of the argument 'data.source'
-                choices = eval(formal.args[[as.character(substitute(data.source))]])
-                ## set the value to its first element as this is the expected behavior
-                data.source = choices[[1]]
-            }
-            else {
-                ## if an argument is passed, use the match function to sort it out for us
-                data.source = match.arg.or.default(data.source, several.ok = TRUE)
-            }
+            ## get the right value when nothing is passed for 'data.source'
+            ## here we need to do a trick, because 'match.arg' returns the whole choice vector instead of the first
+            ## element if nothing is passed but 'several.ok' is set to 'TRUE'. With this solution we get the following
+            ## behavior: if 'data.source' is missing, 'several.ok' will be 'FALSE' making the function return
+            ## the first element of the choice vector. If an argument is present, 'several.ok' will be 'TRUE' allowing
+            ## multiple values for the argument
+            data.source = match.arg(data.source, several.ok = !missing(data.source))
 
             data.source.func = sapply(data.source, function(d) {
                 return(DATASOURCE.TO.ARTIFACT.FUNCTION[[d]])

--- a/util-data.R
+++ b/util-data.R
@@ -1117,24 +1117,15 @@ ProjectData = R6::R6Class("ProjectData",
             ## multiple values for the argument
             data.sources = match.arg(data.sources, several.ok = !missing(data.sources))
 
-            data.source.funcs = sapply(data.sources, function(d) {
-                return(DATASOURCE.TO.ARTIFACT.FUNCTION[[d]])
-            }, USE.NAMES = FALSE)
-
-            data.source.cols = sapply(data.sources, function(d) {
-                return(DATASOURCE.TO.ARTIFACT.COLUMN[[d]])
-            }, USE.NAMES = FALSE)
-
-            ## get actual artifact data
-            data = lapply(data.source.funcs, function(d) {
-                return(self[[d]]())
+            artifacts = lapply(data.sources, function(data.source) {
+                data.source.func = DATASOURCE.TO.ARTIFACT.FUNCTION[[data.source]]
+                data.source.col = DATASOURCE.TO.ARTIFACT.COLUMN[[data.source]]
+                data = self[[data.source.func]]()
+                return(unique(data[[data.source.col]]))
             })
 
-            artifacts = c()
-            for (df in data) {
-                unique.artifacts = unique(df[[data.source.cols]])
-                artifacts = append(artifacts, unique.artifacts)
-            }
+            ## make it a vector
+            artifacts = unlist(artifacts)
 
             ## empty vector if no data exist
             if (is.null(artifacts)) {

--- a/util-data.R
+++ b/util-data.R
@@ -1110,11 +1110,11 @@ ProjectData = R6::R6Class("ProjectData",
             logging::loginfo("Getting artifact data.")
 
             data.source = match.arg.or.default(data.source, several.ok = TRUE)
-            data.source.func = sapply(data.source, function (d) {
+            data.source.func = sapply(data.source, function(d) {
                 return(DATASOURCE.TO.ARTIFACT.FUNCTION[[d]])
             }, USE.NAMES = FALSE)
 
-            data.source.col = sapply(data.source, function (d) {
+            data.source.col = sapply(data.source, function(d) {
                 return(DATASOURCE.TO.ARTIFACT.COLUMN[[d]])
             }, USE.NAMES = FALSE)
 

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -24,7 +24,7 @@
 ## Libraries ---------------------------------------------------------------
 
 requireNamespace("igraph")
-requireNamespace("util-core-peripheral")
+#requireNamespace("util-core-peripheral")
 
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
@@ -330,8 +330,10 @@ metrics.centrality = function(network,
     if (is.null(restrict.classification.to.authors)) {
         ## now check whether both data and network are present
         if (!is.null(network) && !is.null(proj.data)) {
-            ## in this case calculate the restrict parameter based on the edge relation
-            restrict.classification.to.authors = relations.to.authors(proj.data, network)
+            ## in this case calculate the restrict parameter based on the edge relation along with the authors from
+            ## these data.sources
+            restrict.classification.to.authors = get.authors.by.data.source(get.data.sources.from.relations(network),
+                                                                            proj.Data)
         }
         ## else leave the parameter at \code{NULL} which still serves as a default value for the
         ## \code{get.auther.class.by.type} function
@@ -344,13 +346,13 @@ metrics.centrality = function(network,
                                      restrict.classification.to.authors = restrict.classification.to.authors)
 
     ## bind the two data frames for core and peripheral together
-    centrality = rbind(class$core, class$peripheral)
+    centrality = rbind(class[["core"]], class[["peripheral"]])
 
     ## set column names accordingly
     colnames(centrality) = CENTRALITY_COLUMN_NAMES
 
     ## order by centrality (desc) (with NA being at the bottom) and then by name (asc)
-    centrality = centrality[order(-centrality$centrality, centrality$name), ]
+    centrality = centrality[order(-centrality[["centrality"]], centrality[["name"]]), ]
 
     return(centrality)
 }

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -153,22 +153,22 @@ metrics.modularity = function(network, community.detection.algorithm = igraph::c
 #'
 #' @param network the simplified network to be examined
 #'
-#' @return The smallworldness value of the network. \code{NA} if the number of edges is too large.
+#' @return The smallworldness value of the network.
 metrics.smallworldness = function(network) {
-    ## construct Erdös-Renyi network 'h' with same number of vertices and edges as the given network 'network'
-    h = try(igraph::erdos.renyi.game(n = igraph::vcount(network),
-                                     p.or.m = igraph::ecount(network),
-                                     type = "gnm",
-                                     directed = FALSE))
-
-    ## handle the case that there are too many edges
-    if (inherits(h, "try-error")) {
-        # print user warning instead of igraph error
-        logging::logwarn("The input network has too many edges. Try again with a simplified network.")
-
-        # stop the execution and return NA
-        return(NA)
+    ## first check whether the network is simplified
+    if (!is.simple(network)) {
+        ## if this is not the case, raise an error and stop the execution
+        error.message = "The input network has too many edges. Try again with a simplified network."
+        logging::error(error.message)
+        stop(error.message)
     }
+
+    ## else construct Erdös-Renyi network 'h' with same number of vertices and edges as the given network 'network',
+    ## as the requirement of the function is fulfilled
+    h = igraph::erdos.renyi.game(n = igraph::vcount(network),
+                                 p.or.m = igraph::ecount(network),
+                                 type = "gnm",
+                                 directed = FALSE)
 
     ## compute clustering coefficients
     g.cc = igraph::transitivity(network, type = "global")
@@ -194,14 +194,9 @@ metrics.smallworldness = function(network) {
 #'
 #' @return \code{TRUE}, if the network is smallworld,
 #'         \code{FALSE}, if it is not,
-#'         \code{NA}, if the network has too many edges and an error occured in \code{metrics.smallworldness}.
+#'         \code{NA}, if an error occured.
 metrics.is.smallworld = function(network) {
     s.delta = metrics.smallworldness(network)
-
-    ## return NA if an error occurred
-    if (is.na(s.delta)) {
-        return (NA)
-    }
 
     ## else return whether the network is smallworld
     return(s.delta > 1)

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -286,11 +286,9 @@ metrics.hierarchy = function(network) {
 
 
 ## The column headers for a centrality data frame calculated by the function \code{metrics.vertex.centralities}
-VERTEX_CENTRALITIES_COLUMN_NAMES = c("vertex.name", "centrality")
+VERTEX.CENTRALITIES.COLUMN.NAMES = c("vertex.name", "centrality")
 
 #' Calculate the centrality value for vertices from a network and project data.
-#' Only considers vertices from the network that are also present in the project data and the
-#' \code{restrict.classification.to.vertices} vector.
 #' If a \code{ProjectData} is supplied, only vertices from the network that are also present in the project data are
 #' considered. Otherwise, if no custom vector \code{restrict.classification.to.vertices} is supplied, all vertices of
 #' the network are considered.
@@ -345,7 +343,7 @@ metrics.vertex.centralities = function(network,
     centrality = rbind(class[["core"]], class[["peripheral"]])
 
     ## set column names accordingly
-    colnames(centrality) = VERTEX_CENTRALITIES_COLUMN_NAMES
+    colnames(centrality) = VERTEX.CENTRALITIES.COLUMN.NAMES
 
     ## order by centrality (descending) (with NA being at the bottom) and then by name (ascending)
     centrality = centrality[order(-centrality[["centrality"]], centrality[["name"]]), ]

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -24,7 +24,6 @@
 ## Libraries ---------------------------------------------------------------
 
 requireNamespace("igraph")
-#requireNamespace("util-core-peripheral")
 
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
@@ -37,12 +36,12 @@ requireNamespace("igraph")
 #'
 #' @return A data frame containing the name of the vertex with with maximum degree its degree.
 metrics.hub.degree = function(network, mode = c("total", "in", "out")) {
-    ## check whether network is empty, i.e. if it has no vertices
-    if (network.vcount() == 0) {
+    ## check whether the network is empty, i.e., if it has no vertices
+    if (igraph::vcount(network) == 0) {
         ## print user warning instead of igraph error
-        logging::logwarn("The input network has no vertices. Try again with network consisting of at least one vertex.")
+        logging::logwarn("The input network has no vertices. Will return NA right away.")
 
-        ## stop the execution and return NA
+        ## cancel the execution and return NA
         return(NA)
     }
 
@@ -99,7 +98,7 @@ metrics.density = function(network) {
 #' @param directed whether to consider directed paths in directed networks [default: TRUE]
 #' @param unconnected whether there are vertices in the network that are not connected.
 #'                    If \code{TRUE} only the lengths of the existing paths are considered and averaged;
-#'                    if \code{FALSE} the length of the missing paths are counted having length vcount(graph), one longer than
+#'                    if \code{FALSE} the length of the missing paths are counted having length \code{vcount(graph)}, one longer than
 #'                    the longest possible geodesic in the network (from igraph documentation) [default: TRUE]
 #'
 #' @return The average path length of the given network.
@@ -114,8 +113,7 @@ metrics.avg.pathlength = function(network, directed = TRUE, unconnected = TRUE) 
 #' Such vertices are removed from all average calculations for any averaging \code{cc.type}.
 #'
 #' @param network the network to be examined
-#' @param cc.type the type of cluserting coefficient to be calculated
-#'                [default: c("global", "local", "barrat", "localaverage")]
+#' @param cc.type the type of cluserting coefficient to be calculated [default: "global"]
 #'
 #' @return The clustering coefficient of the network.
 metrics.clustering.coeff = function(network, cc.type = c("global", "local", "barrat", "localaverage")) {
@@ -157,7 +155,7 @@ metrics.modularity = function(network, community.detection.algorithm = igraph::c
 #'
 #' @return The smallworldness value of the network. \code{NA} if the number of edges is too large.
 metrics.smallworldness = function(network) {
-    ## construct Erdös-Renyi network with same number of vertices and edges as g
+    ## construct Erdös-Renyi network 'h' with same number of vertices and edges as the given network 'network'
     h = try(igraph::erdos.renyi.game(n = igraph::vcount(network),
                                      p.or.m = igraph::ecount(network),
                                      type = "gnm",
@@ -166,7 +164,7 @@ metrics.smallworldness = function(network) {
     ## handle the case that there are too many edges
     if (inherits(h, "try-error")) {
         # print user warning instead of igraph error
-        logging::logwarn("The input network has too many edges. Try again with a simplified network..")
+        logging::logwarn("The input network has too many edges. Try again with a simplified network.")
 
         # stop the execution and return NA
         return(NA)

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -351,7 +351,7 @@ metrics.centrality = function(network,
     ## set column names accordingly
     colnames(centrality) = CENTRALITY_COLUMN_NAMES
 
-    ## order by centrality (desc) (with NA being at the bottom) and then by name (asc)
+    ## order by centrality (descending) (with NA being at the bottom) and then by name (ascending)
     centrality = centrality[order(-centrality[["centrality"]], centrality[["name"]]), ]
 
     return(centrality)

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -326,8 +326,21 @@ metrics.vertex.centralities = function(network,
         if (!is.null(network) && !is.null(proj.data)) {
             ## in this case calculate the restrict parameter based on the edge relation along with the vertices from
             ## these data.sources
-            restrict.classification.to.vertices = get.authors.by.data.source(get.data.sources.from.relations(network),
-                                                                             proj.Data)
+
+            ## first check whether the network only consists of author vertices
+            ## therefore get a vector with all vertex types
+            vertex.types = unique(igraph::V(network)$type)
+            if (vertex.types == c("author")) {
+                ## in this case, use the 'get.authors.by.data.source' function to get the author list
+                restrict.classification.to.vertices = get.authors.by.data.source(
+                    get.data.sources.from.relations(network),
+                    proj.Data)
+            }
+            else if ("artifact" %in% vertex.types) {
+                ## in this case, always use artifact relation, as both unipartite edges connecting to artifact vertices
+                ## as well as bipartite have an artifact relation
+                restrict.classification.to.vertices = get.artifacts(get.data.sources.from.relations(network))
+            }
         }
         ## else leave the parameter at 'NULL' which still serves as a default value for the
         ## 'get.auther.class.by.type' function

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -32,7 +32,7 @@ requireNamespace("igraph")
 #' Determine the maximum degree for the given network.
 #'
 #' @param network the network to be examined
-#' @param mode the mode to be used for determining the degrees [default: c("total", "in", "out")]
+#' @param mode the mode to be used for determining the degrees [default: "total"]
 #'
 #' @return A dataframe containing the name of the vertex with with maximum degree its degree.
 metrics.hub.degree = function(network, mode = c("total", "in", "out")) {
@@ -46,7 +46,7 @@ metrics.hub.degree = function(network, mode = c("total", "in", "out")) {
 #' Calculate the average degree of a network.
 #'
 #' @param network the network to be examined
-#' @param mode the mode to be used for determining the degrees [default: c("total", "in", "out")]
+#' @param mode the mode to be used for determining the degrees [default: "total"]
 #'
 #' @return The average degree of the vertices in the network.
 metrics.avg.degree = function(network, mode = c("total", "in", "out")) {
@@ -88,8 +88,8 @@ metrics.density = function(network) {
 #' @param network the network to be examined
 #' @param directed whether to consider directed paths in directed networks [default: TRUE]
 #' @param unconnected whether there are vertices in the network that are not connected.
-#'                    If TRUE only the lengths of the existing paths are considered and averaged;
-#'                    if FALSE the length of the missing paths are counted having length vcount(graph), one longer than
+#'                    If \code{TRUE} only the lengths of the existing paths are considered and averaged;
+#'                    if \code{FALSE} the length of the missing paths are counted having length vcount(graph), one longer than
 #'                    the longest possible geodesic in the network (from igraph documentation) [default: TRUE]
 #'
 #' @return The average path length of the given network.
@@ -145,7 +145,7 @@ metrics.modularity = function(network, community.detection.algorithm = igraph::c
 #'
 #' @param network the simplified network to be examined
 #'
-#' @return The smallworldness value of the network. \code{-1} if the number of edges is too large.
+#' @return The smallworldness value of the network. \code{NA} if the number of edges is too large.
 metrics.smallworldness = function(network) {
     ## construct Erdös-Renyi network with same number of vertices and edges as g
     h = try(igraph::erdos.renyi.game(n = igraph::vcount(network),

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -16,6 +16,7 @@
 ## Copyright 2017-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017-2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
+## Copyright 2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -85,11 +86,14 @@ metrics.density = function(network) {
 #' Calculate the average path length for the given network.
 #'
 #' @param network the network to be examined
-#' @param directed whether to consider directed paths in directed networks
-#' @param unconnected whether all vertices of the network are connected
+#' @param directed whether to consider directed paths in directed networks [default: TRUE]
+#' @param unconnected whether there are vertices in the network that are not connected.
+#'                    If TRUE only the lengths of the existing paths are considered and averaged;
+#'                    if FALSE the length of the missing paths are counted having length vcount(graph), one longer than
+#'                    the longest possible geodesic in the network (from igraph documentation) [default: TRUE]
 #'
-#' @return The average pathlength of the given network.
-metrics.avg.pathlength = function(network, directed, unconnected) {
+#' @return The average path length of the given network.
+metrics.avg.pathlength = function(network, directed = TRUE, unconnected = TRUE) {
     avg.pathlength = igraph::average.path.length(network, directed = directed, unconnected = unconnected)
     return(c(avg.pathlength = avg.pathlength))
 }

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -198,7 +198,7 @@ metrics.smallworldness = function(network) {
 metrics.is.smallworld = function(network) {
     s.delta = metrics.smallworldness(network)
 
-    ## else return whether the network is smallworld
+    ## return whether the network is smallworld
     return(s.delta > 1)
 }
 
@@ -294,7 +294,7 @@ VERTEX.CENTRALITIES.COLUMN.NAMES = c("vertex.name", "centrality")
 #' the network are considered.
 #'
 #' @param network the network containing the vertices to classify
-#' @param proj.data the \code{ProjectData} containing the vertices to classify
+#' @param proj.data the \code{ProjectData} containing the authors or artifacts to classify
 #' @param type a character string declaring the classification metric. The classification metric determines which
 #'             numerical characteristic of vertices is chosen as their centrality value.
 #'             The parameter only supports network-based options/metrics:
@@ -343,11 +343,11 @@ metrics.vertex.centralities = function(network,
             }
         }
         ## else leave the parameter at 'NULL' which still serves as a default value for the
-        ## 'get.auther.class.by.type' function
+        ## 'get.author.class.by.type' function
     }
 
     ## calculate the centrality tables
-    class = get.auther.class.by.type(network = network,
+    class = get.author.class.by.type(network = network,
                                      proj.data = proj.data,
                                      type = type,
                                      restrict.classification.to.authors = restrict.classification.to.vertices)

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -32,7 +32,7 @@ requireNamespace("igraph")
 #' Determine the maximum degree for the given network.
 #'
 #' @param network the network to be examined
-#' @param mode the mode to be used for determining the degrees
+#' @param mode the mode to be used for determining the degrees [default: c("total", "in", "out")]
 #'
 #' @return A dataframe containing the name of the vertex with with maximum degree its degree.
 metrics.hub.degree = function(network, mode = c("total", "in", "out")) {
@@ -46,7 +46,7 @@ metrics.hub.degree = function(network, mode = c("total", "in", "out")) {
 #' Calculate the average degree of a network.
 #'
 #' @param network the network to be examined
-#' @param mode the mode to be used for determining the degrees
+#' @param mode the mode to be used for determining the degrees [default: c("total", "in", "out")]
 #'
 #' @return The average degree of the vertices in the network.
 metrics.avg.degree = function(network, mode = c("total", "in", "out")) {
@@ -59,9 +59,9 @@ metrics.avg.degree = function(network, mode = c("total", "in", "out")) {
 #' Calculate all vertex degrees for the given network
 #'
 #' @param network the network to be examined
-#' @param sort whether the resulting dataframe is to be sorted by the vertex degree
+#' @param sort whether the resulting dataframe is to be sorted by the vertex degree [default: TRUE]
 #' @param sort.decreasing if sorting is active, this says whether the dataframe is to be
-#'            sorted in descending or ascending order
+#'                        sorted in descending or ascending order [default: TRUE]
 #'
 #' @return A dataframe containing the vertices and their respective degrees.
 metrics.vertex.degrees = function(network, sort = TRUE, sort.decreasing = TRUE) {
@@ -105,6 +105,7 @@ metrics.avg.pathlength = function(network, directed = TRUE, unconnected = TRUE) 
 #'
 #' @param network the network to be examined
 #' @param cc.type the type of cluserting coefficient to be calculated
+#'                [default: c("global", "local", "barrat", "localaverage")]
 #'
 #' @return The clustering coefficient of the network.
 metrics.clustering.coeff = function(network, cc.type = c("global", "local", "barrat", "localaverage")) {
@@ -117,7 +118,7 @@ metrics.clustering.coeff = function(network, cc.type = c("global", "local", "bar
 #'
 #' @param network the network to be examined
 #' @param community.detection.algorithm the algorithm to be used for the detection of communities
-#'            which is required for the calculation of the clustering coefficient
+#'            which is required for the calculation of the clustering coefficient [default: igraph::cluster_walktrap]
 #'
 #' @return The modularity value for the given network.
 metrics.modularity = function(network, community.detection.algorithm = igraph::cluster_walktrap) {

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -336,10 +336,17 @@ metrics.vertex.centralities = function(network,
                     get.data.sources.from.relations(network),
                     proj.Data)
             }
-            else if ("artifact" %in% vertex.types) {
+            else if (vertex.types == c("artifact")) {
                 ## in this case, always use artifact relation, as both unipartite edges connecting to artifact vertices
                 ## as well as bipartite have an artifact relation
                 restrict.classification.to.vertices = get.artifacts(get.data.sources.from.relations(network))
+            }
+            else {
+                ## when both vertex types are present, compute both authors and artifacts into one vector
+                restrict.authors = get.authors.by.data.source(get.data.sources.from.relations(network),
+                                                              proj.Data)
+                restrict.artifacts = get.artifacts(get.data.sources.from.relations(network))
+                restrict.classification.to.vertices = append(restrict.authors, restrict.artifacts)
             }
         }
         ## else leave the parameter at 'NULL' which still serves as a default value for the

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -173,6 +173,18 @@ metrics.smallworldness = function(network) {
     return (c(smallworldness = s.delta))
 }
 
+#' Decide, whether a network is smallworld or not.
+#'
+#' @param network the network to be examined
+#'
+#' @return \code{TRUE}, if the network is smallworld,
+#'         \code{FALSE}, otherwise.
+metrics.is.smallworld = function(network) {
+    s.delta = metrics.smallworldness(network)
+    return(s.delta > 1)
+}
+
+
 #' Determine scale freeness of a network using the power law fitting method.
 #'
 #' @param network the network to be examined

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -36,6 +36,15 @@ requireNamespace("igraph")
 #'
 #' @return A dataframe containing the name of the vertex with with maximum degree its degree.
 metrics.hub.degree = function(network, mode = c("total", "in", "out")) {
+    ## check whether network is empty, i.e. if it has no vertices
+    if (network.vcount() == 0) {
+        # print user warning instead of igraph error
+        logging::logwarn("The input network has no vertices. Try again with network consisting of at least one vertex.")
+
+        # stop the execution and return NA
+        return(NA)
+    }
+
     mode = match.arg(mode)
     degrees = igraph::degree(network, mode = c(mode))
     vertex = which.max(degrees)

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -285,64 +285,67 @@ metrics.hierarchy = function(network) {
 }
 
 
-## The column headers for a centrality data frame calculated by the function \code{metrics.centrality}
-CENTRALITY_COLUMN_NAMES = c("name", "centrality")
+## The column headers for a centrality data frame calculated by the function \code{metrics.vertex.centralities}
+VERTEX_CENTRALITIES_COLUMN_NAMES = c("vertex.name", "centrality")
 
-#' Calculate the centrality value for authors from a network and project data.
-#' Only considers authors from the network that are also present in the project data and the
-#' \code{restrict.classification.to.authors} vector.
+#' Calculate the centrality value for vertices from a network and project data.
+#' Only considers vertices from the network that are also present in the project data and the
+#' \code{restrict.classification.to.vertices} vector.
+#' If a \code{ProjectData} is supplied, only vertices from the network that are also present in the project data are
+#' considered. Otherwise, if no custom vector \code{restrict.classification.to.vertices} is supplied, all vertices of
+#' the network are considered.
 #'
-#' @param network the network containing the authors to classify
-#' @param proj.data the \code{ProjectData} containing the authors to classify
+#' @param network the network containing the vertices to classify
+#' @param proj.data the \code{ProjectData} containing the vertices to classify
 #' @param type a character string declaring the classification metric. The classification metric determines which
-#'             numerical characteristic of authors is chosen as their centrality value.
+#'             numerical characteristic of vertices is chosen as their centrality value.
 #'             The parameter only supports network-based options/metrics:
 #'              - "network.degree"
 #'              - "network.eigen"
 #'              - "network.hierarchy"
 #'             [defalt: "network.degree"]
-#' @param restrict.classification.to.authors a vector of author names. Only authors that are contained within this
-#'                                           vector are to be classified. Authors that appear in the vector but are not
-#'                                           part of the classification result (i.e., they are not present in the
-#'                                           underlying data) will be added to it afterwards (with a centrality value of
-#'                                           \code{NA}). \code{NULL} means that the restriction is automatically
-#'                                           calculated from the network's edge relations if and only if both network
-#'                                           and data are present. In any other case \code{NULL} will not introduce any
-#'                                           further restriction. [default: NULL]
-#' @return a data.frame with the columns \code{"author.name"} and \code{"centrality"} containing the centrality values
-#'         for each respective author
-metrics.centrality = function(network,
+#' @param restrict.classification.to.vertices a vector of vertex names. Only vertices that are contained within this
+#'                                            vector are to be classified. Vertices that appear in the vector but are
+#'                                            not part of the classification result (i.e., they are not present in the
+#'                                            underlying data) will be added to it afterwards (with a centrality value
+#'                                            of \code{NA}). \code{NULL} means that the restriction is automatically
+#'                                            calculated from the data based on the network's edge relations if and only
+#'                                            if both network and data are present. In any other case \code{NULL} will
+#'                                            not introduce any further restriction. [default: NULL]
+#' @return a data.frame with the columns \code{"vertex.name"} and \code{"centrality"} containing the centrality values
+#'         for each respective vertex
+metrics.vertex.centralities = function(network,
                               proj.data,
                               type = c("network.degree",
                                        "network.eigen",
                                        "network.hierarchy"),
-                              restrict.classification.to.authors = NULL) {
+                              restrict.classification.to.vertices = NULL) {
     type = match.arg(type)
 
-    ## check whether the restrict parameter is set to default (\code{NULL})
-    if (is.null(restrict.classification.to.authors)) {
+    ## check whether the restrict parameter is set to default 'NULL'
+    if (is.null(restrict.classification.to.vertices)) {
         ## now check whether both data and network are present
         if (!is.null(network) && !is.null(proj.data)) {
-            ## in this case calculate the restrict parameter based on the edge relation along with the authors from
+            ## in this case calculate the restrict parameter based on the edge relation along with the vertices from
             ## these data.sources
-            restrict.classification.to.authors = get.authors.by.data.source(get.data.sources.from.relations(network),
-                                                                            proj.Data)
+            restrict.classification.to.vertices = get.authors.by.data.source(get.data.sources.from.relations(network),
+                                                                             proj.Data)
         }
-        ## else leave the parameter at \code{NULL} which still serves as a default value for the
-        ## \code{get.auther.class.by.type} function
+        ## else leave the parameter at 'NULL' which still serves as a default value for the
+        ## 'get.auther.class.by.type' function
     }
 
     ## calculate the centrality tables
     class = get.auther.class.by.type(network = network,
                                      proj.data = proj.data,
                                      type = type,
-                                     restrict.classification.to.authors = restrict.classification.to.authors)
+                                     restrict.classification.to.authors = restrict.classification.to.vertices)
 
     ## bind the two data frames for core and peripheral together
     centrality = rbind(class[["core"]], class[["peripheral"]])
 
     ## set column names accordingly
-    colnames(centrality) = CENTRALITY_COLUMN_NAMES
+    colnames(centrality) = VERTEX_CENTRALITIES_COLUMN_NAMES
 
     ## order by centrality (descending) (with NA being at the bottom) and then by name (ascending)
     centrality = centrality[order(-centrality[["centrality"]], centrality[["name"]]), ]

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -96,7 +96,7 @@ metrics.density = function(network) {
 #'
 #' @param network the network to be examined
 #' @param directed whether to consider directed paths in directed networks [default: TRUE]
-#' @param unconnected whether there are vertices in the network that are not connected.
+#' @param unconnected whether there are subnetworks in the network that are not connected.
 #'                    If \code{TRUE} only the lengths of the existing paths are considered and averaged;
 #'                    if \code{FALSE} the length of the missing paths are counted having length \code{vcount(graph)}, one longer than
 #'                    the longest possible geodesic in the network (from igraph documentation) [default: TRUE]

--- a/util-networks.R
+++ b/util-networks.R
@@ -1573,13 +1573,21 @@ delete.authors.without.specific.edges = function(network, specific.edge.types =
 #' Calculate the data sources of a network based on its edge relations
 #'
 #' @param network the network with the relations to be extracted
-#' @return a vector with all data.sources from the network
+#' @return a vector with all data.sources from the network; an element is set to \code{NA} if the network contains an
+#' empty relation, i.e. \code{character(0)}
 get.data.sources.from.relations = function(network) {
     ## get all relations in the network
     data.sources = unique(igraph::E(network)[["relation"]])
 
     ## map them to data sources respectively using the defined translation constant
     data.sources = sapply(data.sources, function(relation) {
+        ## check for a \code{character(0)} relation and abort if there is one
+        if (length(relation) == 0) {
+            logging::logwarn("There seems to be an empty relation in the network. Cannot proceed.")
+            return (NA)
+        }
+
+        ## use the translation constant to get the appropriate data source
         return(RELATION.TO.DATASOURCE[["relation"]])
     })
 

--- a/util-networks.R
+++ b/util-networks.R
@@ -1610,3 +1610,24 @@ get.sample.network = function() {
 
     return(network)
 }
+
+
+## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+## Helper functions---------------------------------------------------------
+
+#' Calculate the data sources of a network based on its edge relations and compute all authors from these
+#'
+#' @param proj.data the \code{Proj.Data} object corresponding to the network
+#' @param network the network with the relations to be extracted
+#' @return a list of authors from the data sources of the relations in the network
+relations.to.authors = function(proj.data, network) {
+    ## get all relations in the network
+    data.sources = unique(E(net)$relation)
+
+    ## map them to data sources respectively using the defined translation constant
+    data.sources = apply(data.sources, 2, function(relation) {
+        return(RELATION.TO.DATASOURCE[relation])
+    })
+
+    return(get.authors.by.data.source(data.sources))
+}

--- a/util-networks.R
+++ b/util-networks.R
@@ -18,6 +18,7 @@
 ## Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 ## Copyright 2018-2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2020 by Anselm Fehnker <anselm@muenster.de>
+## Copyright 2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -1570,7 +1571,7 @@ delete.authors.without.specific.edges = function(network, specific.edge.types =
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
 ## Helper functions---------------------------------------------------------
 
-#' Calculate the data sources of a network based on its edge relations
+#' Calculate the data sources of a network based on its edge relations.
 #'
 #' @param network the network with the relations to be extracted
 #' @return a vector with all data.sources from the network; an element is set to \code{NA} if the network contains an

--- a/util-networks.R
+++ b/util-networks.R
@@ -1577,7 +1577,7 @@ delete.authors.without.specific.edges = function(network, specific.edge.types =
 #' empty relation, i.e. \code{character(0)}
 get.data.sources.from.relations = function(network) {
     ## get all relations in the network
-    data.sources = unique(igraph::E(network)[["relation"]])
+    data.sources = unique(igraph::E(network)$relation)
 
     ## map them to data sources respectively using the defined translation constant
     data.sources = sapply(data.sources, function(relation) {
@@ -1588,8 +1588,8 @@ get.data.sources.from.relations = function(network) {
         }
 
         ## use the translation constant to get the appropriate data source
-        return(RELATION.TO.DATASOURCE[["relation"]])
-    })
+        return(RELATION.TO.DATASOURCE[[relation]])
+    }, USE.NAMES = FALSE) # avoid element names as we only want the data source's name
 
     return(data.sources)
 }
@@ -1604,7 +1604,6 @@ SAMPLE.DATA = normalizePath("./sample")
 #'
 #' @return the sample network
 get.sample.network = function() {
-
     ## project configuration
     proj.conf = ProjectConf$new(SAMPLE.DATA, "testing", "sample", "feature")
     proj.conf$update.values(list(commits.filter.base.artifact = FALSE))

--- a/util-networks.R
+++ b/util-networks.R
@@ -1568,6 +1568,26 @@ delete.authors.without.specific.edges = function(network, specific.edge.types =
 
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+## Helper functions---------------------------------------------------------
+
+#' Calculate the data sources of a network based on its edge relations
+#'
+#' @param network the network with the relations to be extracted
+#' @return a vector with all data.sources from the network
+get.data.sources.from.relations = function(network) {
+    ## get all relations in the network
+    data.sources = unique(igraph::E(network)[["relation"]])
+
+    ## map them to data sources respectively using the defined translation constant
+    data.sources = sapply(data.sources, function(relation) {
+        return(RELATION.TO.DATASOURCE[["relation"]])
+    })
+
+    return(data.sources)
+}
+
+
+## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
 ## Sample network ----------------------------------------------------------
 
 SAMPLE.DATA = normalizePath("./sample")
@@ -1609,25 +1629,4 @@ get.sample.network = function() {
     network = igraph::set.graph.attribute(network, "layout", lay)
 
     return(network)
-}
-
-
-## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
-## Helper functions---------------------------------------------------------
-
-#' Calculate the data sources of a network based on its edge relations and compute all authors from these
-#'
-#' @param proj.data the \code{Proj.Data} object corresponding to the network
-#' @param network the network with the relations to be extracted
-#' @return a list of authors from the data sources of the relations in the network
-relations.to.authors = function(proj.data, network) {
-    ## get all relations in the network
-    data.sources = unique(E(net)$relation)
-
-    ## map them to data sources respectively using the defined translation constant
-    data.sources = apply(data.sources, 2, function(relation) {
-        return(RELATION.TO.DATASOURCE[relation])
-    })
-
-    return(get.authors.by.data.source(data.sources))
 }


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](https://github.com/se-passau/coronet/blob/master/CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](https://github.com/se-passau/coronet/blob/master/NEWS.md) appropriately.
- [x] The pull request is opened against the branch `dev`.

### Description
Fix some bugs discussed in #181 in `util-network-metrics`:  
- [x] (1) Clarify `metrics.avg.pathlength` (f929248182594613bd203e100268e3e3dce87f34)
- [x] (2) Add default values to several methods (de9988cc171cafdd084701d5a2693a74176a802a)
- [x] (3) Clarify `is.smallworld` (ce1f8124298d73830f3fd96aa84e82ba89181aa6)
- [x] (4) Handle error in `metrics.smallworldness` (4b164bebea1e8258cb93febf51271a4b6f486779)
- [x] (5) Handle empty networks in `metrics.hub.degree` (ec984f46b6f2fc1613e5861e2f33c0fb99ec5c08)
- [x] (6) Integrate centrality functions into `util-network-metrics`
  - [x] (6.1) Add centrality function to simplify getting a centrality data frame (d3cd528609480f87658601ef13326e950a74cce7)
  - [x] (6.2) Automate finding the suitable data source for restricting authors (d1e4413a49ab83a115a7f26719592876371ab264)
  - [x] (6.3) Test new `get.data.sources.from.relations` function (add0c746dde8279da41d180deecf52b91a46095c)
### Changelog

- Add more explanation to `metrics.avg.path.length` and as well as default values for that function.
- Add default parameters to documentation of several other methods missing them.
- Add function `metrics.is.smallworld` to the metrics module in order to unify checks for smallworldness (similar to scalefreeness).
- Handle error in igraph function by printing user warning instead. When calling  `metrics.smallworldness` with a network that is too large, i.e. that has too many edges a warning is being printed and `NA` is returned.
- Add check for empty network in `metrics.hub-degree` function. In the case of an empty network, a warning is being printed and `NA` is returned.
- Add 'metrics.centrality' function to metrics module in order to simplify getting a data frame containing author names
and their respective centrality values.
- Add `get.data.sources.from.relations` to `util-networks.R` which extracts the data sources of a network that were used when building it.