### PR TITLE
Fix wrong ProjectConf after various data splittings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@ and their respective centrality values (d3cd528609480f87658601ef13326e950a74cce7
 - Fix the function `reset.environment()` of both the `ProjectData` and `NetworkBuilder` class; they now reset all the data (PR #199, de091a5e6c70fea5161276d6585bea916178e4de)
 - Adjust the functions `update.commit.message.data()`, `update.pasta.data()`, and `update.synchronicity.data()`: no warning is being printed anymore when being called by the corresponding cleanup function (PR #199, e5c60a50f8fa0f5bf9d362fdf49845d58652dd75)
 - Fix issue where the data path on `RangeData` objects was wrong in special cases. Introduce the (private) flag `built.from.range.data.read` that is set according to how the object has been created (splitting manually or reading codeface ranges) and calculating the data path accordingly (PR #199, cce95279692b8d29ae464e12cfe48e923f417ac7, 917bf64e7a439c6a33b922e04929030479722bd1, 169c034c2364fc56507573e6f2316cc432631ba6). Also add tests for this new behaviour (PR #199, ef5bac63580d171dd7f68da6c4ec7279dcd400b5, 3aa8e7de4b847924afa350a1fc4a53a7f8fa86e1, d454e5a3468d765247ed4827e708b8576e54f87c, 66ad1272148e3d98f9508ff0e83180d967b6abaa)
-- Make splitting no longer modify the original ProjectConf, instead create a copy (c894ccefc0554c85281af74ca8a16e26e6072543)
+- Make splitting no longer modify the original ProjectConf, instead create a copy (e82d056b7a67288addb5989ded1e8c921d5ed0a4)
 
 ## 3.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,6 @@ and their respective centrality values (d3cd528609480f87658601ef13326e950a74cce7
 - Adjust the functions `update.commit.message.data()`, `update.pasta.data()`, and `update.synchronicity.data()`: no warning is being printed anymore when being called by the corresponding cleanup function (PR #199, e5c60a50f8fa0f5bf9d362fdf49845d58652dd75)
 - Fix issue where the data path on `RangeData` objects was wrong in special cases. Introduce the (private) flag `built.from.range.data.read` that is set according to how the object has been created (splitting manually or reading codeface ranges) and calculating the data path accordingly (PR #199, cce95279692b8d29ae464e12cfe48e923f417ac7, 917bf64e7a439c6a33b922e04929030479722bd1, 169c034c2364fc56507573e6f2316cc432631ba6). Also add tests for this new behaviour (PR #199, ef5bac63580d171dd7f68da6c4ec7279dcd400b5, 3aa8e7de4b847924afa350a1fc4a53a7f8fa86e1, d454e5a3468d765247ed4827e708b8576e54f87c, 66ad1272148e3d98f9508ff0e83180d967b6abaa)
 - Make splitting no longer modify the original ProjectConf, instead create a copy (c894ccefc0554c85281af74ca8a16e26e6072543)
->>>>>>> 0cb5372 (Adjust NEWS.md)
 
 ## 3.7
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,8 @@ and their respective centrality values (d3cd528609480f87658601ef13326e950a74cce7
 - Fix the function `reset.environment()` of both the `ProjectData` and `NetworkBuilder` class; they now reset all the data (PR #199, de091a5e6c70fea5161276d6585bea916178e4de)
 - Adjust the functions `update.commit.message.data()`, `update.pasta.data()`, and `update.synchronicity.data()`: no warning is being printed anymore when being called by the corresponding cleanup function (PR #199, e5c60a50f8fa0f5bf9d362fdf49845d58652dd75)
 - Fix issue where the data path on `RangeData` objects was wrong in special cases. Introduce the (private) flag `built.from.range.data.read` that is set according to how the object has been created (splitting manually or reading codeface ranges) and calculating the data path accordingly (PR #199, cce95279692b8d29ae464e12cfe48e923f417ac7, 917bf64e7a439c6a33b922e04929030479722bd1, 169c034c2364fc56507573e6f2316cc432631ba6). Also add tests for this new behaviour (PR #199, ef5bac63580d171dd7f68da6c4ec7279dcd400b5, 3aa8e7de4b847924afa350a1fc4a53a7f8fa86e1, d454e5a3468d765247ed4827e708b8576e54f87c, 66ad1272148e3d98f9508ff0e83180d967b6abaa)
+- Make splitting no longer modify the original ProjectConf, instead create a copy (c894ccefc0554c85281af74ca8a16e26e6072543)
+>>>>>>> 0cb5372 (Adjust NEWS.md)
 
 ## 3.7
 

--- a/tests/test-split-sliding-window.R
+++ b/tests/test-split-sliding-window.R
@@ -88,7 +88,9 @@ test_that("Split a data object time-based (split.basis = 'commits', sliding.wind
         "2016-07-12 16:04:59-2016-07-12 16:06:33"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -186,7 +188,9 @@ test_that("Split a data object time-based (split.basis = 'mails', sliding.window
     )
 
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
 
     ## check data for all ranges
@@ -294,7 +298,9 @@ test_that("Split a data object time-based (split.basis = 'issues', sliding.windo
     )
 
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -382,7 +388,9 @@ test_that("Split a data object time-based (bins = ... , sliding.window = TRUE)."
         "2016-12-31 23:59:59-2017-06-03 03:03:03"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -459,7 +467,9 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (activity.amount).")})
+                     info = "Time ranges (activity.amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -524,7 +534,9 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (too-large activity amount).")})
+                     info = "Time ranges (too-large activity amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -572,7 +584,9 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (number.windows).")})
+                     info = "Time ranges (number.windows).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -667,7 +681,9 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (activity.amount).")})
+                     info = "Time ranges (activity.amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -767,7 +783,9 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
         "2016-07-12 15:58:50-2016-07-12 16:05:38"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -868,7 +886,9 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (too-large activity amount).")})
+                     info = "Time ranges (too-large activity amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -916,7 +936,9 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (number.windows).")})
+                     info = "Time ranges (number.windows).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -1009,7 +1031,9 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
         "2016-10-05 15:30:02-2017-05-23 12:32:40"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -1104,7 +1128,9 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (too-large activity amount).")})
+                     info = "Time ranges (too-large activity amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -1152,7 +1178,9 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (number.windows).")})
+                     info = "Time ranges (number.windows).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(

--- a/tests/test-split-sliding-window.R
+++ b/tests/test-split-sliding-window.R
@@ -90,7 +90,25 @@ test_that("Split a data object time-based (split.basis = 'commits', sliding.wind
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "time-based",
+        split.length = "3 min",
+        split.basis = "commits",
+        split.sliding.window = TRUE,
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:00:29", "2016-07-12 16:01:59",
+                            "2016-07-12 16:03:29", "2016-07-12 16:04:59", "2016-07-12 16:06:29",
+                            "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -190,7 +208,25 @@ test_that("Split a data object time-based (split.basis = 'mails', sliding.window
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "time-based",
+        split.length = "3 years",
+        split.basis = "mails",
+        split.sliding.window = TRUE,
+        split.revisions = c("2004-10-09 18:38:13", "2006-04-10 15:38:13", "2007-10-10 12:38:13",
+                            "2009-04-10 09:38:13", "2010-10-10 06:38:13", "2012-04-10 03:38:13",
+                            "2013-10-10 00:38:13", "2015-04-10 21:38:13", "2016-07-12 16:05:38"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
 
     ## check data for all ranges
@@ -300,7 +336,24 @@ test_that("Split a data object time-based (split.basis = 'issues', sliding.windo
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "time-based",
+        split.length = "2 years",
+        split.basis = "issues",
+        split.sliding.window = TRUE,
+        split.revisions = c("2013-04-21 23:52:09", "2014-04-22 05:52:09", "2015-04-22 11:52:09",
+                            "2016-04-21 17:52:09", "2017-04-21 23:52:09", "2017-05-23 12:32:40"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -390,7 +443,23 @@ test_that("Split a data object time-based (bins = ... , sliding.window = TRUE)."
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "time-based",
+        split.length = c("2016-01-01 00:00:00", "2016-12-31 23:59:59", "2017-06-03 03:03:03"),
+        split.basis = NULL,
+        split.sliding.window = FALSE, ## TODO is this the supposed value
+        split.revisions = c("2016-01-01 00:00:00", "2016-12-31 23:59:59", "2017-06-03 03:03:03"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -469,7 +538,24 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (activity.amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 3,
+        split.basis = "commits",
+        split.sliding.window = TRUE,
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:00:45", "2016-07-12 16:06:10",
+                            "2016-07-12 16:06:20", "2016-07-12 16:06:32", "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -536,7 +622,23 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 18,
+        split.basis = "commits",
+        split.sliding.window = TRUE,
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -586,7 +688,23 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 4,
+        split.basis = "commits",
+        split.sliding.window = FALSE, ## TODO is this the supposed value
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:06:20", "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -683,7 +801,25 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (activity.amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 3,
+        split.basis = "commits",
+        split.sliding.window = TRUE,
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:00:45", "2016-07-12 16:06:10",
+                            "2016-07-12 16:06:20", "2016-07-12 16:06:32", "2016-07-12 16:06:33",
+                            "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -785,7 +921,26 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 3,
+        split.basis = "mails",
+        split.sliding.window = TRUE,
+        split.revisions = c("2004-10-09 18:38:13", "2005-02-09 18:49:49", "2010-07-12 11:05:35",
+                            "2010-07-12 12:05:34", "2010-07-12 12:05:41", "2010-07-12 12:05:42",
+                            "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2016-07-12 15:58:40",
+                            "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:05:38"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -888,7 +1043,23 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 26,
+        split.basis = "mails",
+        split.sliding.window = TRUE,
+        split.revisions = c("2004-10-09 18:38:13", "2016-07-12 16:05:38"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -938,7 +1109,23 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 8,
+        split.basis = "mails",
+        split.sliding.window = FALSE, ## TODO is this the supposed value
+        split.revisions = c("2004-10-09 18:38:13", "2010-07-12 12:05:43", "2016-07-12 16:05:38"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -1033,7 +1220,26 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 9,
+        split.basis = "issues",
+        split.sliding.window = TRUE,
+        split.revisions = c("2013-04-21 23:52:09", "2013-05-06 01:04:34", "2013-05-25 06:22:23",
+                            "2016-07-12 15:30:02", "2016-07-12 15:59:59", "2016-07-12 16:02:02",
+                            "2016-07-12 16:06:30", "2016-07-27 20:12:08", "2016-10-05 15:30:02",
+                            "2017-05-23 12:31:34", "2017-05-23 12:32:40"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -1130,7 +1336,23 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 59,
+        split.basis = "issues",
+        split.sliding.window = TRUE,
+        split.revisions = c("2013-04-21 23:52:09", "2017-05-23 12:32:40"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -1180,7 +1402,23 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must not modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 21,
+        split.basis = "issues",
+        split.sliding.window = FALSE, ## TODO is this the supposed value
+        split.revisions = c("2013-04-21 23:52:09", "2016-07-12 16:02:02", "2017-05-23 12:32:40"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(

--- a/tests/test-split-sliding-window.R
+++ b/tests/test-split-sliding-window.R
@@ -87,9 +87,8 @@ test_that("Split a data object time-based (split.basis = 'commits', sliding.wind
         "2016-07-12 16:03:29-2016-07-12 16:06:29",
         "2016-07-12 16:04:59-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -185,9 +184,10 @@ test_that("Split a data object time-based (split.basis = 'mails', sliding.window
         "2012-04-10 03:38:13-2015-04-10 21:38:13",
         "2013-10-10 00:38:13-2016-07-12 16:05:38"
     )
-    result = proj.conf$get.value("ranges")
 
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+
 
     ## check data for all ranges
     expected.data = list(
@@ -292,9 +292,9 @@ test_that("Split a data object time-based (split.basis = 'issues', sliding.windo
         "2015-04-22 11:52:09-2017-04-21 23:52:09",
         "2016-04-21 17:52:09-2017-05-23 12:32:40"
     )
-    result = proj.conf$get.value("ranges")
 
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -381,8 +381,8 @@ test_that("Split a data object time-based (bins = ... , sliding.window = TRUE)."
         "2016-01-01 00:00:00-2016-12-31 23:59:59",
         "2016-12-31 23:59:59-2017-06-03 03:03:03"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -457,8 +457,9 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         "2016-07-12 16:06:10-2016-07-12 16:06:32",
         "2016-07-12 16:06:20-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (activity.amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (activity.amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -521,8 +522,9 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
     expected = c(
         "2016-07-12 15:58:59-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (too-large activity amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (too-large activity amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -568,8 +570,9 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         "2016-07-12 15:58:59-2016-07-12 16:06:20",
         "2016-07-12 16:06:20-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (number.windows).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (number.windows).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -662,8 +665,9 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         "2016-07-12 16:06:20-2016-07-12 16:06:33",
         "2016-07-12 16:06:32-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (activity.amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (activity.amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -762,8 +766,8 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
         "2016-07-12 15:58:40-2016-07-12 16:05:37",
         "2016-07-12 15:58:50-2016-07-12 16:05:38"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -862,8 +866,9 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
     expected = c(
         "2004-10-09 18:38:13-2016-07-12 16:05:38"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (too-large activity amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (too-large activity amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -909,8 +914,9 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
         "2004-10-09 18:38:13-2010-07-12 12:05:43",
         "2010-07-12 12:05:43-2016-07-12 16:05:38"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (number.windows).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (number.windows).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -1002,8 +1008,8 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
         "2016-07-27 20:12:08-2017-05-23 12:31:34",
         "2016-10-05 15:30:02-2017-05-23 12:32:40"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -1096,8 +1102,9 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
     expected = c(
         "2013-04-21 23:52:09-2017-05-23 12:32:40"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (too-large activity amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (too-large activity amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -1143,8 +1150,9 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
         "2013-04-21 23:52:09-2016-07-12 16:02:02",
         "2016-07-12 16:02:02-2017-05-23 12:32:40"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (number.windows).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (number.windows).")})
 
     ## check data for all ranges
     expected.data = list(

--- a/tests/test-split-sliding-window.R
+++ b/tests/test-split-sliding-window.R
@@ -459,7 +459,7 @@ test_that("Split a data object time-based (bins = ... , sliding.window = TRUE)."
         split.type = "time-based",
         split.length = c("2016-01-01 00:00:00", "2016-12-31 23:59:59", "2017-06-03 03:03:03"),
         split.basis = NULL,
-        split.sliding.window = FALSE, ## TODO is this the supposed value
+        split.sliding.window = FALSE,
         split.revisions = c("2016-01-01 00:00:00", "2016-12-31 23:59:59", "2017-06-03 03:03:03"),
         split.revision.dates = NULL
     )
@@ -710,7 +710,7 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         split.type = "activity-based",
         split.length = 4,
         split.basis = "commits",
-        split.sliding.window = FALSE, ## TODO is this the supposed value
+        split.sliding.window = FALSE,
         split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:06:20", "2016-07-12 16:06:33"),
         split.revision.dates = NULL
     )
@@ -1139,7 +1139,7 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
         split.type = "activity-based",
         split.length = 8,
         split.basis = "mails",
-        split.sliding.window = FALSE, ## TODO is this the supposed value
+        split.sliding.window = FALSE,
         split.revisions = c("2004-10-09 18:38:13", "2010-07-12 12:05:43", "2016-07-12 16:05:38"),
         split.revision.dates = NULL
     )
@@ -1438,7 +1438,7 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
         split.type = "activity-based",
         split.length = 21,
         split.basis = "issues",
-        split.sliding.window = FALSE, ## TODO is this the supposed value
+        split.sliding.window = FALSE,
         split.revisions = c("2013-04-21 23:52:09", "2016-07-12 16:02:02", "2017-05-23 12:32:40"),
         split.revision.dates = NULL
     )

--- a/tests/test-split-sliding-window.R
+++ b/tests/test-split-sliding-window.R
@@ -90,9 +90,11 @@ test_that("Split a data object time-based (split.basis = 'commits', sliding.wind
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "time-based",
@@ -208,9 +210,11 @@ test_that("Split a data object time-based (split.basis = 'mails', sliding.window
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "time-based",
@@ -336,9 +340,11 @@ test_that("Split a data object time-based (split.basis = 'issues', sliding.windo
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "time-based",
@@ -443,9 +449,11 @@ test_that("Split a data object time-based (bins = ... , sliding.window = TRUE)."
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "time-based",
@@ -538,9 +546,11 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (activity.amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -622,9 +632,11 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -688,9 +700,11 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -801,9 +815,11 @@ test_that("Split a data object activity-based (activity.type = 'commits', slidin
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (activity.amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -921,9 +937,11 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1043,9 +1061,11 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1109,9 +1129,11 @@ test_that("Split a data object activity-based (activity.type = 'mails', sliding.
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1220,9 +1242,11 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1336,9 +1360,11 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1402,9 +1428,11 @@ test_that("Split a data object activity-based (activity.type = 'issues', sliding
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must not modify the original ProjectConf.")
+                 info = "Splitting must not modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",

--- a/tests/test-split.R
+++ b/tests/test-split.R
@@ -93,7 +93,9 @@ test_that("Split a data object time-based (split.basis = 'commits').", {
         "2016-07-12 16:04:59-2016-07-12 16:06:33"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -176,7 +178,9 @@ test_that("Split a data object time-based (split.basis = 'mails').", {
         "2013-10-10 00:38:13-2016-07-12 16:05:38"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -263,7 +267,9 @@ test_that("Split a data object time-based (split.basis = 'issues').", {
         "2017-04-21 23:52:09-2017-05-23 12:32:40"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -344,7 +350,9 @@ test_that("Split a data object time-based (bins = ... ).", {
         "2016-01-01 00:00:00-2016-12-31 23:59:59"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -527,7 +535,9 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (activity.amount).")})
+                     info = "Time ranges (activity.amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -586,7 +596,9 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (too-large activity amount).")})
+                     info = "Time ranges (too-large activity amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -634,7 +646,9 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (number.windows).")})
+                     info = "Time ranges (number.windows).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -724,7 +738,9 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
         "2016-07-12 16:05:37-2016-07-12 16:05:38"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -801,7 +817,9 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (too-large activity amount).")})
+                     info = "Time ranges (too-large activity amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -849,7 +867,9 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (number.windows).")})
+                     info = "Time ranges (number.windows).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -937,7 +957,9 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
         "2016-10-05 15:30:02-2017-05-23 12:32:40"
     )
     lapply(results, function(res) {
-        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -1008,7 +1030,9 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (too-large activity amount).")})
+                     info = "Time ranges (too-large activity amount).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(
@@ -1056,7 +1080,9 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
     )
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
-                     info = "Time ranges (number.windows).")})
+                     info = "Time ranges (number.windows).")
+    })
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
 
     ## check data for all ranges
     expected.data = list(

--- a/tests/test-split.R
+++ b/tests/test-split.R
@@ -95,9 +95,11 @@ test_that("Split a data object time-based (split.basis = 'commits').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "time-based",
@@ -196,9 +198,11 @@ test_that("Split a data object time-based (split.basis = 'mails').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "time-based",
@@ -302,9 +306,11 @@ test_that("Split a data object time-based (split.basis = 'issues').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "time-based",
@@ -401,9 +407,11 @@ test_that("Split a data object time-based (bins = ... ).", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "time-based",
@@ -603,9 +611,11 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (activity.amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -680,9 +690,11 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -746,9 +758,11 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -854,9 +868,11 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -951,9 +967,11 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1017,9 +1035,11 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1123,9 +1143,11 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1213,9 +1235,11 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",
@@ -1279,9 +1303,11 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
+
     ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
     expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
-                 info = "splitting must mot modify the original ProjectConf.")
+                 info = "Splitting must mot modify the original ProjectConf.")
+
     ## test that the config contains the correct splitting information
     expected.config = list(
         split.type = "activity-based",

--- a/tests/test-split.R
+++ b/tests/test-split.R
@@ -92,8 +92,8 @@ test_that("Split a data object time-based (split.basis = 'commits').", {
         "2016-07-12 16:01:59-2016-07-12 16:04:59",
         "2016-07-12 16:04:59-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -175,9 +175,8 @@ test_that("Split a data object time-based (split.basis = 'mails').", {
         "2010-10-10 06:38:13-2013-10-10 00:38:13",
         "2013-10-10 00:38:13-2016-07-12 16:05:38"
     )
-    result = proj.conf$get.value("ranges")
-
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -263,9 +262,8 @@ test_that("Split a data object time-based (split.basis = 'issues').", {
         "2015-04-22 11:52:09-2017-04-21 23:52:09",
         "2017-04-21 23:52:09-2017-05-23 12:32:40"
     )
-    result = proj.conf$get.value("ranges")
-
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -345,8 +343,8 @@ test_that("Split a data object time-based (bins = ... ).", {
     expected = c(
         "2016-01-01 00:00:00-2016-12-31 23:59:59"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -527,8 +525,9 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
         "2016-07-12 16:06:10-2016-07-12 16:06:32",
         "2016-07-12 16:06:32-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (activity.amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (activity.amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -585,8 +584,9 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
     expected = c(
         "2016-07-12 15:58:59-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (too-large activity amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (too-large activity amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -632,8 +632,9 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
         "2016-07-12 15:58:59-2016-07-12 16:06:20",
         "2016-07-12 16:06:20-2016-07-12 16:06:33"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (number.windows).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (number.windows).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -722,8 +723,8 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
         "2016-07-12 15:58:40-2016-07-12 16:05:37",
         "2016-07-12 16:05:37-2016-07-12 16:05:38"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -798,8 +799,9 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
     expected = c(
         "2004-10-09 18:38:13-2016-07-12 16:05:38"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (too-large activity amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (too-large activity amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -845,8 +847,9 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
         "2004-10-09 18:38:13-2010-07-12 12:05:43",
         "2010-07-12 12:05:43-2016-07-12 16:05:38"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (number.windows).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (number.windows).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -933,8 +936,8 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
         "2016-07-12 16:06:30-2016-10-05 15:30:02",
         "2016-10-05 15:30:02-2017-05-23 12:32:40"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges.")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")})
 
     ## check data for all ranges
     expected.data = list(
@@ -1003,8 +1006,9 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
     expected = c(
         "2013-04-21 23:52:09-2017-05-23 12:32:40"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (too-large activity amount).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (too-large activity amount).")})
 
     ## check data for all ranges
     expected.data = list(
@@ -1050,8 +1054,9 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
         "2013-04-21 23:52:09-2016-07-12 16:02:02",
         "2016-07-12 16:02:02-2017-05-23 12:32:40"
     )
-    result = proj.conf$get.value("ranges")
-    expect_equal(result, expected, info = "Time ranges (number.windows).")
+    lapply(results, function(res) {
+        expect_equal(res$get.project.conf()$get.value("ranges"), expected,
+                     info = "Time ranges (number.windows).")})
 
     ## check data for all ranges
     expected.data = list(

--- a/tests/test-split.R
+++ b/tests/test-split.R
@@ -95,7 +95,23 @@ test_that("Split a data object time-based (split.basis = 'commits').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "time-based",
+        split.length = "3 min",
+        split.basis = "commits",
+        split.sliding.window = FALSE,
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:01:59", "2016-07-12 16:04:59", "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -180,7 +196,24 @@ test_that("Split a data object time-based (split.basis = 'mails').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "time-based",
+        split.length = "3 years",
+        split.basis = "mails",
+        split.sliding.window = FALSE,
+        split.revisions = c("2004-10-09 18:38:13", "2007-10-10 12:38:13", "2010-10-10 06:38:13",
+                            "2013-10-10 00:38:13", "2016-07-12 16:05:38"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -269,7 +302,23 @@ test_that("Split a data object time-based (split.basis = 'issues').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "time-based",
+        split.length = "2 years",
+        split.basis = "issues",
+        split.sliding.window = FALSE,
+        split.revisions = c("2013-04-21 23:52:09", "2015-04-22 11:52:09", "2017-04-21 23:52:09", "2017-05-23 12:32:40"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -352,7 +401,24 @@ test_that("Split a data object time-based (bins = ... ).", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "time-based",
+        split.length = c("2016-01-01 00:00:00", "2016-12-31 23:59:59"),
+        split.basis = NULL,
+        split.sliding.window = FALSE,
+        split.revisions = c("2016-01-01 00:00:00", "2016-12-31 23:59:59"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
+
 
     ## check data for all ranges
     expected.data = list(
@@ -537,7 +603,23 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (activity.amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 3,
+        split.basis = "commits",
+        split.sliding.window = FALSE,
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:06:10", "2016-07-12 16:06:32", "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -598,7 +680,23 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 18,
+        split.basis = "commits",
+        split.sliding.window = FALSE,
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -648,7 +746,23 @@ test_that("Split a data object activity-based (activity.type = 'commits').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 4,
+        split.basis = "commits",
+        split.sliding.window = FALSE,
+        split.revisions = c("2016-07-12 15:58:59", "2016-07-12 16:06:20", "2016-07-12 16:06:33"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -740,7 +854,25 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 3,
+        split.basis = "mails",
+        split.sliding.window = FALSE,
+        split.revisions = c("2004-10-09 18:38:13", "2010-07-12 11:05:35", "2010-07-12 12:05:41",
+                            "2010-07-12 12:05:44" ,"2016-07-12 15:58:40", "2016-07-12 16:05:37",
+                            "2016-07-12 16:05:38"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -819,7 +951,23 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 26,
+        split.basis = "mails",
+        split.sliding.window = FALSE,
+        split.revisions = c("2004-10-09 18:38:13", "2016-07-12 16:05:38"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -869,7 +1017,23 @@ test_that("Split a data object activity-based (activity.type = 'mails').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 8,
+        split.basis = "mails",
+        split.sliding.window = FALSE,
+        split.revisions = c("2004-10-09 18:38:13", "2010-07-12 12:05:43", "2016-07-12 16:05:38"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -959,7 +1123,24 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
     lapply(results, function(res) {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected, info = "Time ranges.")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 9,
+        split.basis = "issues",
+        split.sliding.window = FALSE,
+        split.revisions = c("2013-04-21 23:52:09", "2013-05-25 06:22:23", "2016-07-12 15:59:59",
+                            "2016-07-12 16:06:30", "2016-10-05 15:30:02", "2017-05-23 12:32:40"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -1032,7 +1213,23 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (too-large activity amount).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 59,
+        split.basis = "issues",
+        split.sliding.window = FALSE,
+        split.revisions = c("2013-04-21 23:52:09", "2017-05-23 12:32:40"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(
@@ -1082,7 +1279,23 @@ test_that("Split a data object activity-based (activity.type = 'issues').", {
         expect_equal(res$get.project.conf()$get.value("ranges"), expected,
                      info = "Time ranges (number.windows).")
     })
-    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"))
+    ## This value should not change, so we compare it with the default, which is `c("v1-v2", "v2-v3")`.
+    expect_equal(proj.conf$get.value("ranges"), c("v1-v2", "v2-v3"),
+                 info = "splitting must mot modify the original ProjectConf.")
+    ## test that the config contains the correct splitting information
+    expected.config = list(
+        split.type = "activity-based",
+        split.length = 21,
+        split.basis = "issues",
+        split.sliding.window = FALSE,
+        split.revisions = c("2013-04-21 23:52:09", "2016-07-12 16:02:02", "2017-05-23 12:32:40"),
+        split.revision.dates = NULL
+    )
+    lapply(results, function(res) {
+        actual = lapply(names(expected.config), res$get.project.conf()$get.value)
+        names(actual) = names(expected.config)
+        expect_equal(expected.config, actual)
+    })
 
     ## check data for all ranges
     expected.data = list(

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -582,7 +582,6 @@ add.vertex.attribute.artifact.count = function(list.of.networks, project.data, n
     nets.with.attr = split.and.add.vertex.attribute(
         list.of.networks, project.data, name, aggregation.level, default.value,
         function(range, range.data, net) {
-            ## FIXME we need to implement this also for the other kinds of artifacts
             lapply(range.data$group.artifacts.by.data.column("commits", "author.name"),
                    function(x) {
                        length(unique(x[["artifact"]]))

--- a/util-split.R
+++ b/util-split.R
@@ -20,6 +20,7 @@
 ## Copyright 2017-2018 by Thomas Bock <bockthom@fim.uni-passau.de>
 ## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
+## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -54,11 +55,14 @@ requireNamespace("lubridate") # for date conversion
 #'                    [default: "commits"]
 #' @param sliding.window logical indicating whether the splitting should be performed using a sliding-window approach
 #'                       [default: FALSE]
+#' @param project.conf.new the new project config to construct the \code{RangeData} objects.
+#'                         If \code{NULL}, a clone of \code{project.data$get.project.conf()} will be used.
+#'                         [default: NULL]
 #'
 #' @return the list of RangeData objects, each referring to one time period
 split.data.time.based = function(project.data, time.period = "3 months", bins = NULL,
                                  number.windows = NULL, split.basis = c("commits", "mails", "issues"),
-                                 sliding.window = FALSE) {
+                                 sliding.window = FALSE, project.conf.new = NULL) {
     ## get actual raw data
     data = list(
         commits = project.data$get.commits(),
@@ -122,6 +126,12 @@ split.data.time.based = function(project.data, time.period = "3 months", bins = 
         sliding.window = FALSE
     }
 
+    if (is.null(project.conf.new)) {
+        ## Clone the project configuration, so that splitting repeatedly does not interfere
+        ## with the same configuration.
+        project.conf.new = project.data$get.project.conf()$clone()
+    }
+
     if (!sliding.window) {
 
         ## split data
@@ -143,14 +153,14 @@ split.data.time.based = function(project.data, time.period = "3 months", bins = 
         names(data.split) = bins.ranges
 
         ## adapt project configuration
-        project.data$get.project.conf()$set.revisions(bins, bins.date)
+        project.conf.new$set.revisions(bins, bins.date)
 
         ## construct RangeData objects
         logging::logdebug("Constructing RangeData objects.")
         cf.data = parallel::mclapply(bins.ranges, function(range) {
             logging::logdebug("Constructing data for range %s.", range)
             ## construct object for current range
-            cf.range.data = RangeData$new(project.data$get.project.conf(), range)
+            cf.range.data = RangeData$new(project.conf.new, range)
             ## get data for current range
             df.list = data.split[[range]]
 
@@ -185,15 +195,15 @@ split.data.time.based = function(project.data, time.period = "3 months", bins = 
         cf.data = split.data.time.based.by.ranges(project.data, ranges)
 
         ## update project configuration
-        project.data$get.project.conf()$set.revisions(bins, bins.date, sliding.window = TRUE)
+        project.conf.new$set.revisions(bins, bins.date, sliding.window = TRUE)
         for (cf in cf.data) {
             ## re-set project configuration due to object duplication
-            cf.conf = cf$set.project.conf(project.data$get.project.conf())
+            cf.conf = cf$set.project.conf(project.conf.new)
         }
     }
 
     ## add splitting information to project configuration
-    project.data$get.project.conf()$set.splitting.info(
+    project.conf.new$set.splitting.info(
         type = "time-based",
         length = if (split.by.bins) bins else time.period,
         basis = split.basis,
@@ -224,11 +234,14 @@ split.data.time.based = function(project.data, time.period = "3 months", bins = 
 #'                       'sliding.window = FALSE') [default: NULL]
 #' @param sliding.window logical indicating whether the splitting should be performed using a sliding-window approach
 #'                       [default: FALSE]
+#' @param project.conf.new the new project config to construct the \code{RangeData} objects.
+#'                         If \code{NULL}, a clone of \code{project.data$get.project.conf()} will be used.
+#'                         [default: NULL]
 #'
 #' @return the list of RangeData objects, each referring to one time period
 split.data.activity.based = function(project.data, activity.type = c("commits", "mails", "issues"),
                                      activity.amount = 5000, number.windows = NULL,
-                                     sliding.window = FALSE) {
+                                     sliding.window = FALSE, project.conf.new = NULL) {
 
     ## get basis for splitting process
     activity.type = match.arg(activity.type)
@@ -249,6 +262,12 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
 
     ## get amount of available activity
     activity = length(unique(data[[activity.type]][[ id.column[[activity.type]] ]]))
+
+    if (is.null(project.conf.new)) {
+        ## Clone the project configuration, so that splitting repeatedly does not interfere
+        ## with the same configuration.
+        project.conf.new = project.data$get.project.conf()$clone()
+    }
 
     ## activity amount given (number of windows NOT given)
     if (is.null(number.windows)) {
@@ -285,7 +304,8 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
 
     ## split the data based on the extracted timestamps
     logging::logdebug("Splitting data based on time windows arising from activity bins.")
-    cf.data = split.data.time.based(project.data, bins = bins.date, split.basis = activity.type)
+    cf.data = split.data.time.based(project.data, bins = bins.date, split.basis = activity.type,
+                                    project.conf.new = project.conf.new)
 
     ## perform additional steps for sliding-window approach:
     ## for activity-based sliding-window bins to work, we need to crop the data appropriately and,
@@ -329,7 +349,8 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
 
         ## split data for sliding windows
         cf.data.sliding = split.data.activity.based(project.data.clone, activity.type = activity.type,
-                                                    activity.amount = activity.amount, sliding.window = FALSE)
+                                                    activity.amount = activity.amount, sliding.window = FALSE,
+                                                    project.conf.new = project.conf.new)
 
         ## append data to normally-split data
         cf.data = append(cf.data, cf.data.sliding)
@@ -377,15 +398,15 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
         }
 
         ## update project configuration
-        project.data$get.project.conf()$set.revisions(bins, bins.date, sliding.window = TRUE)
+        project.conf.new$set.revisions(bins, bins.date, sliding.window = TRUE)
         for (cf in cf.data) {
             ## re-set project configuration due to object duplication
-            cf.conf = cf$set.project.conf(project.data$get.project.conf(), reset.environment = FALSE)
+            cf.conf = cf$set.project.conf(project.conf.new, reset.environment = FALSE)
         }
     }
 
     ## add splitting information to project configuration
-    project.data$get.project.conf()$set.splitting.info(
+    project.conf.new$set.splitting.info(
         type = "activity-based",
         length = activity.amount,
         basis = activity.type,

--- a/util-split.R
+++ b/util-split.R
@@ -277,6 +277,10 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
         }
         ## compute the number of time windows according to the activity amount
         number.windows = ceiling(activity / activity.amount)
+        if (activity < activity.amount) {
+            logging::logwarn("Can not form bins of %s %s for splitting data %s, as there are only %s data rows.",
+                             activity.amount, activity.type, project.data$get.class.name(), activity)
+        }
     }
     ## number of windows given (ignoring amount of activity)
     else {

--- a/util-split.R
+++ b/util-split.R
@@ -278,8 +278,13 @@ split.data.activity.based = function(project.data, activity.type = c("commits", 
         ## compute the number of time windows according to the activity amount
         number.windows = ceiling(activity / activity.amount)
         if (activity < activity.amount) {
-            logging::logwarn("Can not form bins of %s %s for splitting data %s, as there are only %s data rows.",
-                             activity.amount, activity.type, project.data$get.class.name(), activity)
+            activity.type.pretty = list(
+                commits = "commits",
+                mails = "mails",
+                issues = "issue events"
+            )[[activity.type]]
+            logging::logwarn("Can not form bins of %s %s for splitting data %s, as there are only %s %s.",
+                             activity.amount, activity.type.pretty, project.data$get.class.name(), activity, activity.type.pretty)
         }
     }
     ## number of windows given (ignoring amount of activity)


### PR DESCRIPTION
- [x] I adhere to the coding conventions (described [here](https://github.com/se-passau/coronet/blob/master/CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](https://github.com/se-passau/coronet/blob/master/NEWS.md) appropriately.
- [x] The pull request is opened against the branch `dev`.

### Description

Make splitting create new configuration objects for the split data results, as discussed in #198.

Closes #198