### PR TITLE
Necessary adjustments for the recently released R version 4.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
-## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 # Drone CI Setup
@@ -38,9 +38,15 @@ steps:
   - Rscript tests.R
   depends_on: [clone]
 
+- name: R-4.1
+  pull: if-not-exists
+  image: r-base:4.1.0
+  commands: *runTests
+  depends_on: [clone]
+
 - name: R-4.0
   pull: if-not-exists
-  image: r-base:4.0.3
+  image: r-base:4.0.5
   commands: *runTests
   depends_on: [clone]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ and their respective centrality values (d3cd528609480f87658601ef13326e950a74cce7
 - Add check for empty network in `metrics.hub.degree` function. In the case of an empty network, a warning is being printed and `NA` is returned (PR #195, 4b164bebea1e8258cb93febf51271a4b6f486779)
 - Adjust the function `ProjectData$get.artifacts`: Rename its single parameter to `data.sources` and change the function so that it can extract the artifacts for multiple data sources at once. The default is still that only artifacts from the commit data are extracted. (PR #195, cf795f26652b00de5d717c703c688af55a972943, 70c05ecd1e3c0f10810acc2b2ae06a3eb8856317, 5a46ff4d428af7f301fe57d6e9e10421f553a9cc, fd767bb37ca608c28d9ff4a449415cc0e863d7ee)
 - Rename `get.issues` to `get.issues.filtered`, and write a new `get.issues` to get the unfiltered issues so that these methods follow the naming scheme known from the respective methods for commits(b9dd94c8575b8cab40d0d1185368854f84299d87)
+- Add R version 4.1 to test suite and adjust missing time-zone attributes on `NA` vectors or empty POSIXct vectors which are correctly added as of R version 4.1 (PR #203, 6b7fb36478325185f80f95e03dd0a0135bf44346, 98c56715502cf5140d98796dc2d6cb18f71760b2, 09d11ab631de8051ca317f36652ab0fee9cc0cce)
 
 ### Fixed
 - Fix fencing issue timing data so that issue events "happen" after the issue was created. Since only `commit_added` events are affected, that only happens for these. (issue #185, 627873c641410182ca8fee0e78b95d7bda1e8e6b, 6ff585d9da1da3432668605f0c09f8e182ad0d2f)

--- a/tests.R
+++ b/tests.R
@@ -12,7 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2017, 2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
-## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
@@ -27,7 +27,6 @@ source("util-init.R")
 library("methods") # to prevent weird error during logger initialization (see #153)
 library("logging")
 logging::basicConfig(level = "DEBUG")
-assign("last.warning", NULL, envir = baseenv())
 options(mc.cores = 1L)
 
 

--- a/util-misc.R
+++ b/util-misc.R
@@ -16,7 +16,7 @@
 ## Copyright 2017 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2017-2018 by Thomas Bock <bockthom@fim.uni-passau.de>
-## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018-2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## All Rights Reserved.
@@ -171,7 +171,7 @@ create.empty.data.frame = function(columns, data.types = NULL) {
         ## replace column with column of correct type
         switch(tolower(data.types[i]),
                "posixct" = {
-                   column = as.POSIXct(column)
+                   column = lubridate::with_tz(as.POSIXct(column), tzone = TIMEZONE)
                },
                "integer" = {
                    column = as.integer(column)

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -14,6 +14,7 @@
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2018-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2018-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018-2019 by Klara Schlüter <schluete@fim.uni-passau.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2020 by Christian Hechtl <hechtl@cs.uni-saarland.de>
@@ -624,6 +625,9 @@ add.vertex.attribute.first.activity = function(list.of.networks, project.data,
     aggregation.level = match.arg.or.default(aggregation.level, default = "complete")
     parsed.activity.types = match.arg.or.default(activity.types, several.ok = TRUE)
 
+    ## make sure that the default value contains a tzone attribute (even if the default value is NA)
+    default.value = get.date.from.string(default.value)
+
     ## the given default.value is interpreted as default per author and type.
     type.default = default.value
 
@@ -949,6 +953,9 @@ add.vertex.attribute.artifact.first.occurrence = function(list.of.networks, proj
                                                           default.value = NA) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "complete")
 
+    ## make sure that the default value contains a tzone attribute (even if the default value is NA)
+    default.value = get.date.from.string(default.value)
+
     nets.with.attr = split.and.add.vertex.attribute(
         list.of.networks, project.data, name, aggregation.level, default.value,
         function(range, range.data, net) {
@@ -974,6 +981,9 @@ add.vertex.attribute.artifact.first.occurrence = function(list.of.networks, proj
 #' @return A list containing per author a list of first activity values named with the corresponding activity type.
 get.first.activity.data = function(range.data, activity.types = c("commits", "mails", "issues"),
                                    default.value = NA) {
+
+    ## make sure that the default value contains a tzone attribute (even if the default value is NA)
+    default.value = get.date.from.string(default.value)
 
     ## get data for each activity type and extract minimal date for each author in each type,
     ## resulting in a list of activity types with each item containing a list of authors


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [X] I adhere to the coding conventions (described [here](https://github.com/se-passau/coronet/blob/master/CONTRIBUTING.md)) in my code.
- [X] I have updated the copyright headers of the files I have modified.
- [X] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [X] I have put signed-off tags in *all* commits.
- [X] I have updated the changelog file [NEWS.md](https://github.com/se-passau/coronet/blob/master/NEWS.md) appropriately.
- [X] The pull request is opened against the branch `dev`.

### Description

A few days ago, R version 4.1.0 was released. The new R version brings a few adjustments and fixes, which in turn involve a few minor adjustments to let our test suite run successfully even with the new R version.

In particular, there are two fixes in R 4.1.0 that break our test suite:
- The base environment `baseenv()` is locked now. That is, we cannot clear the variable `last.warning` any more at the beginning of the test suite as `last.warning` belongs to the base environment. However, we can just remove the corresponding statement in our test suite as we ignore warnings anyway. (98c5671)
- In previous R versions, empty POSIXct vectors (e.g., `c()`) as well as `NA` vectors of class POSIXct did not have an `tzone` attribute (which was actually a bug in R). In the new R version, this has been fixed. As we did not take care of that `tzone` attribute when creating empty POSIXct vectors or specifying `NA` as a default value for a date (as R itself did not take care of either), some tests fail when comparing dates containing an `NA` value. This can be easily fixed by making sure that the `tzone` is set correctly when creating empty data frames, and also by calling `get.date.from.string` when specifying `NA` as the default value of a date (e.g., when computing vertex attribute "first activity"). (09d11ab)

Last but not least, consistently add R version 4.1 (as of now, 4.1.0) to our CI test pipeline and update the patch release of R version 4.0 to its most recent patch release 4.0.5 (which is the last patch release of R 4.0). (6b7fb36)
