### PR TITLE
Add new threshold calculation for network-based classifications and other small fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 - Add per-author vertex attributes regarding counting of issues, issue-creations, issue-comments, mails, mail-threads, ... (like mail thread count, issue creation count) (PR #194, issue #188, 9f9150a97ffbb64607df0ddcbce299e16c2580da, 7260d62cf6f1470584753f76970d19664638eeed, 139f70b67903909bcd4c57e26afa458681a869f2, eb4f649c04155e22195627072e0f08bb8fe65dc4, 627873c641410182ca8fee0e78b95d7bda1e8e6b, 1e1406f4a0898cac3e61a7bc9a5aa665dceef79f, 98e11abc651b5fe0ec994eddea078635b0d6f0b2, a566caec6d7e649cc495d292a19eca8a7ffccde8)
 - Add functionality that allows to read any data source at any point in time, even after splitting. In this case, the read data is automatically cut to the corresponding range on the `RangeData` object (PR #201, 7f9394f528068f52957be67ab7e2efb733011c6b). Additionally, changing the configuration parameters concerning additional data sources, the environment of a `ProjectData` object is no longer reset (PR #201, eed45ac1f97b4915ec42fb869f34359da1df4c60)
 - Add new configuration parameters `commits.locked`, `mails.locked` and `issues.locked` to `ProjectConf` which, when set to `TRUE`, prevent the respective getters from triggering the read of the data if it is not present yet (PR #201, 382167790e7d096b539eeed6464efeb9bb501d43)
+- Add support for classifying developers on the basis of more count-based classification metrics, including mail-count, mail-thread count, issue-count, issue-comment count, issue-commented-in count, and issue-created count (issue #70, PR #209, d7b2455ece9840caba7c3a46704d2a62a11bee57, 6f737c8859519867928acc4e545c89bfd91b1e2e)
 
 ### Changed/Improved
 - Add `.drone.yml` to enable running our CI pipelines on drone.io (PR #191, 1c5804b59c582cf34af6970b435add51452fbd11)
@@ -31,6 +32,9 @@
 - Add R version 4.1 to test suite and adjust missing time-zone attributes on `NA` vectors or empty POSIXct vectors which are correctly added as of R version 4.1 (PR #203, 6b7fb36478325185f80f95e03dd0a0135bf44346, 98c56715502cf5140d98796dc2d6cb18f71760b2, 09d11ab631de8051ca317f36652ab0fee9cc0cce)
 - Splitting no longer loads all (additional) data sources, but only the ones that have already been cached in the `ProjectData` (PR #201, 52a3014b3c4a1d6dda1347adcffed4e90fae1d2b, aec898e105ff5478fb75ba488b56c9c258a17a80, de1bbfe644c52200e80a769e7c0e447c3a087278)
 - Change the internal representation of empty data from `NULL` to empty data frames and adapt function `get.cached.data.sources()` of `ProjectData` which returns a vector of all data sources that are cached (including additional and filtered data sources) (PR #201 aec898e105ff5478fb75ba488b56c9c258a17a80, e55d088f926ae7a069761864855c179c04ed07dc); additionally, introduce new function `is.data.source.cached()` in `util-data.R` that returns a logical vector indicating which of the given data sources are cached (PR #201, b49cc5df4da04af9df2ae9bcdc7847fafb6befc9, 491e70c44dd71e4d51b40ee83bc8eb598d413bc0)
+- Change the threshold calculation for the classification of developers to use a quantile approach when classifying on the basis of network centrality metrics (issue #205, PR #209, 5128252572ab6471a9dd5437360232622c33e958)
+- Improve the documentation in `util-core-peripheral.R` by adding roxygen skeleton documentation to undocumented functions (issue #70, PR #209, a3d5ca7a5f8c021e0bed588219321798388790ac, 6f737c8859519867928acc4e545c89bfd91b1e2e)
+- Change the `$` notation to the bracket notation in `util-core-peripehral.R` (issue #70, PR #209, 6f737c8859519867928acc4e545c89bfd91b1e2e)
 
 ### Fixed
 - Fix fencing issue timing data so that issue events "happen" after the issue was created. Since only `commit_added` events are affected, that only happens for these. (issue #185, 627873c641410182ca8fee0e78b95d7bda1e8e6b, 6ff585d9da1da3432668605f0c09f8e182ad0d2f)
@@ -43,6 +47,8 @@
 - Fix plotting an empty network via `plot.network` (03f986d760da8f8fec0e7aa530672736ea3068c7)
 - Fix behavior of `construct.ranges` when only one range has to bee constructed and `sliding.window = TRUE` (000314b961247c55051f03da3b2034fbc668847e)
 - Add package `reshape2` to the install script as this package is used in module `util-plot-evolution.R` for quite a while but never has been added to the list of packages to install (7bb4e7bc15b77c1faf8ddf8655c820822be25f80)
+- Fix data tests in `test-data.R` to use deep clones of `ProjectData` objects (PR #209, d75373a56d9de9da3bd6d6f08c1bba0ed10b8425)
+- Fix the `update.values()` function in `util-conf.R` to delete the `value` field if the new value is equal to the default value as the comparison of two otherwise equal `Conf` objects fails without this (PR #209, d75373a56d9de9da3bd6d6f08c1bba0ed10b8425)
 
 
 ## 3.7

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -144,12 +144,32 @@ test_that("get.author.class", {
     expected = list(core = prepared.authors, peripheral = prepared.authors)
     expect_identical(result, expected)
 
-    ## Check empty input data (no columns):
-    expect_error(get.author.class(data.frame(author.name = character(0), foo = numeric(0)), "foo", classification.metric.type = "count"), NA) # expect that no error occurs
-    ## Check empty input data (not enough columns) (1):
-    expect_error(get.author.class(data.frame(), "foo", classification.metric.type = "count"), NA) # expect that no error occurs
-    ## Check empty input data (not enough columns) (2):
-    expect_error(get.author.class(data.frame(author.name = character(0)), "foo", classification.metric.type = "count"), NA) # expect that no error occurs
+    ## Check empty input data for count-based classification (no columns):
+    expect_error(get.author.class(data.frame(author.name = character(0), foo = numeric(0)), "foo",
+                                  classification.metric.type = "count"), NA) # expect that no error occurs
+    ## Check empty input data for count-based classification (not enough columns) (1):
+    expect_error(get.author.class(data.frame(), "foo",
+                                  classification.metric.type = "count"), NA) # expect that no error occurs
+    ## Check empty input data for count-based classification (not enough columns) (2):
+    expect_error(get.author.class(data.frame(author.name = character(0)), "foo",
+                                  classification.metric.type = "count"), NA) # expect that no error occurs
+
+    ## Check empty input data for network-based classification (no columns):
+    expect_error(get.author.class(data.frame(author.name = character(0), foo = numeric(0)), "foo",
+                                  classification.metric.type = "network")) # expect that no error occurs
+    ## Check empty input data for network-based classification (not enough columns) (1):
+    expect_error(get.author.class(data.frame(), "foo",
+                                  classification.metric.type = "network")) # expect that no error occurs
+    ## Check empty input data for network-based classification (not enough columns) (2):
+    expect_error(get.author.class(data.frame(author.name = character(0)), "foo",
+                                  classification.metric.type = "network")) # expect that no error occurs
+
+    ## Check empty input data without a specified classification metric type (not enough columns) (2):
+    expect_error(get.author.class(data.frame(author.name = character(0)), "foo")) # expect that no error occurs
+
+    ## Check empty input data with wrong classification metric type (not enough columns) (2):
+    expect_error(get.author.class(data.frame(author.name = character(0)), "foo",
+                                  classification.metric.type = "Busted")) # expect that no error occurs
 
 })
 

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -156,20 +156,20 @@ test_that("get.author.class", {
 
     ## Check empty input data for network-based classification (no columns):
     expect_error(get.author.class(data.frame(author.name = character(0), foo = numeric(0)), "foo",
-                                  classification.metric.type = "network")) # expect that no error occurs
+                                  classification.metric.type = "network")) # expect that an error occurs
     ## Check empty input data for network-based classification (not enough columns) (1):
     expect_error(get.author.class(data.frame(), "foo",
-                                  classification.metric.type = "network")) # expect that no error occurs
+                                  classification.metric.type = "network")) # expect that an error occurs
     ## Check empty input data for network-based classification (not enough columns) (2):
     expect_error(get.author.class(data.frame(author.name = character(0)), "foo",
-                                  classification.metric.type = "network")) # expect that no error occurs
+                                  classification.metric.type = "network")) # expect that an error occurs
 
     ## Check empty input data without a specified classification metric type (not enough columns) (2):
-    expect_error(get.author.class(data.frame(author.name = character(0)), "foo")) # expect that no error occurs
+    expect_error(get.author.class(data.frame(author.name = character(0)), "foo")) # expect that an error occurs
 
     ## Check empty input data with wrong classification metric type (not enough columns) (2):
     expect_error(get.author.class(data.frame(author.name = character(0)), "foo",
-                                  classification.metric.type = "Busted")) # expect that no error occurs
+                                  classification.metric.type = "Busted")) # expect that an error occurs
 
 })
 

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -123,6 +123,22 @@ test_that("Mail-count classification" , {
     expect_equal(expected, result)
 })
 
+test_that("Mail-thread-count classification" , {
+
+    ## Act
+    result = get.author.class.mail.thread.count(proj.data)
+
+    ## Assert
+    expected.core = data.frame(author.name = c("Björn", "Hans", "Olaf", "Fritz fritz@example.org", "Thomas"),
+                               mail.thread.count = c(3, 2, 2, 1, 1))
+    expected.peripheral = data.frame(author.name = c("georg", "udo"), mail.thread.count = c(1, 1))
+    expected = list(core = expected.core, peripheral = expected.peripheral)
+
+    row.names(result$core) = NULL
+    row.names(result$peripheral) = NULL
+    expect_equal(expected, result)
+})
+
 test_that("Issue-count classification" , {
 
     ## Act
@@ -193,7 +209,7 @@ test_that("get.author.class", {
     ## 1) Arrange
     prepared.authors = data.frame(author.name = c("AAA", "BBB", "CCC", "DDD", "EEE"), centrality = c(1, 1, 1, 1, 1))
     ## 2) Act
-    result = get.author.class(prepared.authors, "centrality", classification.metric.type = "count")
+    result = get.author.class(prepared.authors, "centrality", classification.category = "count")
     ## 3) Assert
     expected = list(core = prepared.authors[1:4, ], peripheral = prepared.authors[5, ])
     expect_identical(result, expected)
@@ -202,7 +218,7 @@ test_that("get.author.class", {
     ## 1) Arrange
     prepared.authors = data.frame(author.name = c("AAA", "BBB", "CCC"), centrality = c(0.5, 0.29, 0.21))
     ## 2) Act
-    result = get.author.class(prepared.authors, "centrality", classification.metric.type = "count")
+    result = get.author.class(prepared.authors, "centrality", classification.category = "count")
     ## 3) Assert
     expected = list(core = prepared.authors, peripheral = prepared.authors[0, ])
     expect_identical(result, expected)
@@ -211,7 +227,7 @@ test_that("get.author.class", {
     ## 1) Arrange
     prepared.authors = data.frame(author.name = c("AAA", "BBB", "CCC"), centrality = c(0, 0, 0))
     ## 2) Act
-    result = get.author.class(prepared.authors, "centrality", classification.metric.type = "count")
+    result = get.author.class(prepared.authors, "centrality", classification.category = "count")
     ## 3) Assert
     expected = list(core = prepared.authors[0, ], peripheral = prepared.authors)
     expect_identical(result, expected)
@@ -220,37 +236,37 @@ test_that("get.author.class", {
     ## 1) Arrange
     prepared.authors = data.frame(author.name = character(0), centrality = numeric(0))
     ## 2) Act
-    result = get.author.class(prepared.authors, "centrality", classification.metric.type = "count")
+    result = get.author.class(prepared.authors, "centrality", classification.category = "count")
     ## 3) Assert
     expected = list(core = prepared.authors, peripheral = prepared.authors)
     expect_identical(result, expected)
 
     ## Check empty input data for count-based classification (no columns):
     expect_error(get.author.class(data.frame(author.name = character(0), foo = numeric(0)), "foo",
-                                  classification.metric.type = "count"), NA) # expect that no error occurs
+                                  classification.category = "count"), NA) # expect that no error occurs
     ## Check empty input data for count-based classification (not enough columns) (1):
     expect_error(get.author.class(data.frame(), "foo",
-                                  classification.metric.type = "count"), NA) # expect that no error occurs
+                                  classification.category = "count"), NA) # expect that no error occurs
     ## Check empty input data for count-based classification (not enough columns) (2):
     expect_error(get.author.class(data.frame(author.name = character(0)), "foo",
-                                  classification.metric.type = "count"), NA) # expect that no error occurs
+                                  classification.category = "count"), NA) # expect that no error occurs
 
     ## Check empty input data for network-based classification (no columns):
     expect_error(get.author.class(data.frame(author.name = character(0), foo = numeric(0)), "foo",
-                                  classification.metric.type = "network")) # expect that an error occurs
+                                  classification.category = "network")) # expect that an error occurs
     ## Check empty input data for network-based classification (not enough columns) (1):
     expect_error(get.author.class(data.frame(), "foo",
-                                  classification.metric.type = "network")) # expect that an error occurs
+                                  classification.category = "network")) # expect that an error occurs
     ## Check empty input data for network-based classification (not enough columns) (2):
     expect_error(get.author.class(data.frame(author.name = character(0)), "foo",
-                                  classification.metric.type = "network")) # expect that an error occurs
+                                  classification.category = "network")) # expect that an error occurs
 
     ## Check empty input data without a specified classification metric type (not enough columns) (2):
     expect_error(get.author.class(data.frame(author.name = character(0)), "foo")) # expect that an error occurs
 
     ## Check empty input data with wrong classification metric type (not enough columns) (2):
     expect_error(get.author.class(data.frame(author.name = character(0)), "foo",
-                                  classification.metric.type = "Busted")) # expect that an error occurs
+                                  classification.category = "Busted")) # expect that an error occurs
 
 })
 

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -35,6 +35,7 @@ if (!dir.exists(CF.DATA)) CF.DATA = file.path(".", "tests", "codeface-data")
 
 ## Prepare global setting
 proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+proj.conf$update.value("issues.only.comments", FALSE)
 proj.data = ProjectData$new(proj.conf)
 
 net.conf = NetworkConf$new()
@@ -99,6 +100,86 @@ test_that("LOC-count classification" , {
 
     ## Assert
     expected.core = data.frame(author.name = c("Björn", "Olaf", "Thomas"), loc.count = c(2, 1, 1))
+    expected = list(core = expected.core, peripheral = expected.core[0, ])
+
+    row.names(result$core) = NULL
+    row.names(result$peripheral) = NULL
+    expect_equal(expected, result)
+})
+
+test_that("Mail-count classification" , {
+
+    ## Act
+    result = get.author.class.mail.count(proj.data)
+
+    ## Assert
+    expected.core = data.frame(author.name = c("Hans", "Björn", "Olaf", "Fritz fritz@example.org"),
+                               mail.count = c(7, 3, 2, 1))
+    expected.peripheral = data.frame(author.name = c("Thomas", "georg", "udo"), mail.count = c(1, 1, 1))
+    expected = list(core = expected.core, peripheral = expected.peripheral)
+
+    row.names(result$core) = NULL
+    row.names(result$peripheral) = NULL
+    expect_equal(expected, result)
+})
+
+test_that("Issue-count classification" , {
+
+    ## Act
+    result = get.author.class.issue.count(proj.data, issue.type = "all")
+
+    ## Assert
+    expected.core = data.frame(author.name = c("Björn", "Olaf", "Thomas"), issue.count = c(6, 6, 4))
+    expected.peripheral = data.frame(author.name = c("Karl", "Max", "udo"), issue.count = c(1, 1, 1))
+    expected = list(core = expected.core, peripheral = expected.peripheral)
+
+    row.names(result$core) = NULL
+    row.names(result$peripheral) = NULL
+    expect_equal(expected, result)
+})
+
+test_that("Issue-comment-count classification" , {
+
+    ## Act
+    result = get.author.class.issue.comment.count(proj.data, issue.type = "issues")
+
+    ## Assert
+    expected.core = data.frame(author.name = c("Björn", "Olaf", "Max"),
+                               issue.comment.count = c(9, 4, 3))
+    expected.peripheral = data.frame(author.name = c("Thomas", "Karl"),
+                               issue.comment.count = c(2, 1))
+    expected = list(core = expected.core, peripheral = expected.peripheral)
+
+    row.names(result$core) = NULL
+    row.names(result$peripheral) = NULL
+    expect_equal(expected, result)
+})
+
+test_that("Issue-commented-in-count classification" , {
+
+    ## Act
+    result = get.author.class.issue.commented.in.count(proj.data)
+
+    ## Assert
+    expected.core = data.frame(author.name = c("Björn", "Olaf", "Thomas"),
+                               issue.commented.in.count = c(5, 3, 3))
+    expected.peripheral = data.frame(author.name = c("Karl", "Max"),
+                                     issue.commented.in.count = c(1, 1))
+    expected = list(core = expected.core, peripheral = expected.peripheral)
+
+    row.names(result$core) = NULL
+    row.names(result$peripheral) = NULL
+    expect_equal(expected, result)
+})
+
+test_that("Issue-created-count classification" , {
+
+    ## Act
+    result = get.author.class.issue.created.count(proj.data, issue.type = "pull.requests")
+
+    ## Assert
+    expected.core = data.frame(author.name = c("Björn", "Olaf", "Thomas"),
+                               issue.created.count = c(1, 1, 1))
     expected = list(core = expected.core, peripheral = expected.core[0, ])
 
     row.names(result$core) = NULL

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -15,6 +15,7 @@
 ## Copyright 2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
 ## Copyright 2019 by Christian Hechtl <hechtl@fim.uni-passau.de>
+## Copyright 2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -48,8 +49,8 @@ test_that("Vertex-degree classification using 'restrict.classification.to.author
                                              restrict.classification.to.authors = c("Olaf", "Björn", "Darth Sidious"))
 
     ## Assert
-    expected.core = data.frame(author.name = c("Olaf", "Björn"), vertex.degree = c(4, 2))
-    expected.peripheral = data.frame(author.name = c("Darth Sidious"), vertex.degree = c(NA))
+    expected.core = data.frame(author.name = c("Olaf"), vertex.degree = c(4))
+    expected.peripheral = data.frame(author.name = c("Björn", "Darth Sidious"), vertex.degree = c(2, NA))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
     row.names(result$core) = NULL
@@ -64,9 +65,10 @@ test_that("Eigenvector classification", {
     result = get.author.class.network.eigen(network)
 
     ## Assert
-    expected.core = data.frame(author.name = c("Olaf", "Thomas", "Björn", "udo", "Fritz fritz@example.org"),
-                               eigen.centrality = c(1.0, 0.7116, 0.7116, 0.25, 0.25))
-    expected.peripheral = data.frame(author.name = c("georg", "Hans"), eigen.centrality = c(0.25, 0.25))
+    expected.core = data.frame(author.name = c("Olaf"),
+                               eigen.centrality = c(1.0))
+    expected.peripheral = data.frame(author.name = c("Thomas", "Björn", "udo", "Fritz fritz@example.org", "georg", "Hans"),
+                                     eigen.centrality = c(0.7116, 0.7116, 0.25, 0.25, 0.25, 0.25))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
     row.names(result$core) = NULL
@@ -110,7 +112,7 @@ test_that("get.author.class", {
     ## 1) Arrange
     prepared.authors = data.frame(author.name = c("AAA", "BBB", "CCC", "DDD", "EEE"), centrality = c(1, 1, 1, 1, 1))
     ## 2) Act
-    result = get.author.class(prepared.authors, "centrality")
+    result = get.author.class(prepared.authors, "centrality", classification.metric.type = "count")
     ## 3) Assert
     expected = list(core = prepared.authors[1:4, ], peripheral = prepared.authors[5, ])
     expect_identical(result, expected)
@@ -119,7 +121,7 @@ test_that("get.author.class", {
     ## 1) Arrange
     prepared.authors = data.frame(author.name = c("AAA", "BBB", "CCC"), centrality = c(0.5, 0.29, 0.21))
     ## 2) Act
-    result = get.author.class(prepared.authors, "centrality")
+    result = get.author.class(prepared.authors, "centrality", classification.metric.type = "count")
     ## 3) Assert
     expected = list(core = prepared.authors, peripheral = prepared.authors[0, ])
     expect_identical(result, expected)
@@ -128,7 +130,7 @@ test_that("get.author.class", {
     ## 1) Arrange
     prepared.authors = data.frame(author.name = c("AAA", "BBB", "CCC"), centrality = c(0, 0, 0))
     ## 2) Act
-    result = get.author.class(prepared.authors, "centrality")
+    result = get.author.class(prepared.authors, "centrality", classification.metric.type = "count")
     ## 3) Assert
     expected = list(core = prepared.authors[0, ], peripheral = prepared.authors)
     expect_identical(result, expected)
@@ -137,17 +139,17 @@ test_that("get.author.class", {
     ## 1) Arrange
     prepared.authors = data.frame(author.name = character(0), centrality = numeric(0))
     ## 2) Act
-    result = get.author.class(prepared.authors, "centrality")
+    result = get.author.class(prepared.authors, "centrality", classification.metric.type = "count")
     ## 3) Assert
     expected = list(core = prepared.authors, peripheral = prepared.authors)
     expect_identical(result, expected)
 
     ## Check empty input data (no columns):
-    expect_error(get.author.class(data.frame(author.name = character(0), foo = numeric(0)), "foo"), NA) # expect that no error occurs
+    expect_error(get.author.class(data.frame(author.name = character(0), foo = numeric(0)), "foo", classification.metric.type = "count"), NA) # expect that no error occurs
     ## Check empty input data (not enough columns) (1):
-    expect_error(get.author.class(data.frame(), "foo"), NA) # expect that no error occurs
+    expect_error(get.author.class(data.frame(), "foo", classification.metric.type = "count"), NA) # expect that no error occurs
     ## Check empty input data (not enough columns) (2):
-    expect_error(get.author.class(data.frame(author.name = character(0)), "foo"), NA) # expect that no error occurs
+    expect_error(get.author.class(data.frame(author.name = character(0)), "foo", classification.metric.type = "count"), NA) # expect that no error occurs
 
 })
 

--- a/tests/test-data.R
+++ b/tests/test-data.R
@@ -12,6 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
+## Copyright 2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## Copyright 2018-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2020-2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
@@ -40,7 +41,7 @@ test_that("Compare two ProjectData objects on empty data", {
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY_EMPTY, ARTIFACT)
     proj.conf$update.value("pasta", TRUE)
     proj.data.one = ProjectData$new(project.conf = proj.conf)
-    proj.data.two = proj.data.one$clone()
+    proj.data.two = proj.data.one$clone(deep = TRUE)
 
     expect_true(proj.data.one$equals(proj.data.two), info = "Two identical ProjectData objects (clone).")
 
@@ -76,7 +77,7 @@ test_that("Compare two ProjectData objects on empty data", {
     proj.data.one$set.project.conf.entry("synchronicity", TRUE)
     proj.data.one$set.project.conf.entry("synchronicity.time.window", 5)
     proj.data.one$get.synchronicity()
-    expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (synchronicity).")
+    expect_false(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (synchronicity).")
     proj.data.two$set.project.conf.entry("synchronicity", TRUE)
     proj.data.two$set.project.conf.entry("synchronicity.time.window", 5)
     proj.data.two$get.synchronicity()
@@ -84,7 +85,7 @@ test_that("Compare two ProjectData objects on empty data", {
 
     proj.data.one$set.project.conf.entry("commit.messages", "message")
     proj.data.one$get.commit.messages()
-    expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (commit.messages).")
+    expect_false(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (commit.messages).")
     proj.data.two$set.project.conf.entry("commit.messages", "message")
     proj.data.two$get.commit.messages()
     expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (commit.messages).")
@@ -97,7 +98,7 @@ test_that("Compare two ProjectData objects on non-empty data", {
     proj.conf$update.value("pasta", TRUE)
 
     proj.data.one = ProjectData$new(project.conf = proj.conf)
-    proj.data.two = proj.data.one$clone()
+    proj.data.two = proj.data.one$clone(deep = TRUE)
 
     expect_true(proj.data.one$equals(proj.data.two), info = "Two identical ProjectData objects (clone).")
 
@@ -115,9 +116,9 @@ test_that("Compare two ProjectData objects on non-empty data", {
     proj.data.one$get.commits()
 
     ## prevent 'equals' from triggering a read when calling the getter
-    proj.conf$update.value("commits.locked", TRUE)
+    proj.data.two$update.project.conf(list("commits.locked" = TRUE))
     expect_false(proj.data.one$equals(proj.data.two), "Two non-identical ProjectData objects (commits).")
-    proj.conf$update.value("commits.locked", FALSE)
+    proj.data.two$update.project.conf(list("commits.locked" = FALSE))
 
     proj.data.two$get.commits()
     expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (commits).")
@@ -126,9 +127,9 @@ test_that("Compare two ProjectData objects on non-empty data", {
     proj.data.two$get.mails()
 
     ## prevent 'equals' from triggering a read when calling the getter
-    proj.conf$update.value("mails.locked", TRUE)
+    proj.data.one$update.project.conf(list("mails.locked" = TRUE))
     expect_false(proj.data.one$equals(proj.data.two), "Two non-identical ProjectData objects (mails).")
-    proj.conf$update.value("mails.locked", FALSE)
+    proj.data.one$update.project.conf(list("mails.locked" = FALSE))
 
     proj.data.one$get.mails()
     expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (mails).")
@@ -137,9 +138,9 @@ test_that("Compare two ProjectData objects on non-empty data", {
     proj.data.one$get.issues.filtered()
 
     ## prevent 'equals' from triggering a read when calling the getter
-    proj.conf$update.value("issues.locked", TRUE)
+    proj.data.two$update.project.conf(list("issues.locked" = TRUE))
     expect_false(proj.data.one$equals(proj.data.two), "Two non-identical ProjectData objects (issues.filtered).")
-    proj.conf$update.value("issues.locked", FALSE)
+    proj.data.two$update.project.conf(list("issues.locked" = FALSE))
 
     proj.data.two$get.issues.filtered()
     expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (issues.filtered).")
@@ -193,7 +194,7 @@ test_that("Compare two RangeData objects", {
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
     proj.data.base = ProjectData$new(project.conf = proj.conf)
     range.data.one = proj.data.base$get.data.cut.to.same.date("commits")
-    range.data.two = range.data.one$clone()
+    range.data.two = range.data.one$clone(deep = TRUE)
 
     ## compare the two equal RangeData objects
     expect_true(range.data.one$equals(range.data.two))

--- a/tests/test-data.R
+++ b/tests/test-data.R
@@ -77,7 +77,7 @@ test_that("Compare two ProjectData objects on empty data", {
     proj.data.one$set.project.conf.entry("synchronicity", TRUE)
     proj.data.one$set.project.conf.entry("synchronicity.time.window", 5)
     proj.data.one$get.synchronicity()
-    expect_false(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (synchronicity).")
+    expect_false(proj.data.one$equals(proj.data.two), "Two non-identical ProjectData objects (synchronicity).")
     proj.data.two$set.project.conf.entry("synchronicity", TRUE)
     proj.data.two$set.project.conf.entry("synchronicity.time.window", 5)
     proj.data.two$get.synchronicity()
@@ -85,7 +85,7 @@ test_that("Compare two ProjectData objects on empty data", {
 
     proj.data.one$set.project.conf.entry("commit.messages", "message")
     proj.data.one$get.commit.messages()
-    expect_false(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (commit.messages).")
+    expect_false(proj.data.one$equals(proj.data.two), "Two non-identical ProjectData objects (commit.messages).")
     proj.data.two$set.project.conf.entry("commit.messages", "message")
     proj.data.two$get.commit.messages()
     expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects (commit.messages).")

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -13,6 +13,7 @@
 ##
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2017-2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
+## Copyright 2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## Copyright 2017-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2018-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
 ## Copyright 2018-2019 by Klara Schlüter <schluete@fim.uni-passau.de>
@@ -1370,7 +1371,7 @@ test_that("Test addition of attributes despite of empty data", {
 
     ## add author-role attribute:
     ## 1) construct empty classification
-    classification = list(get.author.class(data.frame(), "foo"))
+    classification = list(get.author.class(data.frame(), "foo", classification.metric.type = "count"))
     names(classification) = range
     ## 2) add attribute
     net.author.role = add.vertex.attribute.author.role(networks, classification, default = "unclassified")[[1]]

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -1371,7 +1371,7 @@ test_that("Test addition of attributes despite of empty data", {
 
     ## add author-role attribute:
     ## 1) construct empty classification
-    classification = list(get.author.class(data.frame(), "foo", classification.metric.type = "count"))
+    classification = list(get.author.class(data.frame(), "foo", classification.category = "count"))
     names(classification) = range
     ## 2) add attribute
     net.author.role = add.vertex.attribute.author.role(networks, classification, default = "unclassified")[[1]]

--- a/util-conf.R
+++ b/util-conf.R
@@ -259,21 +259,21 @@ Conf = R6::R6Class("Conf",
                     paste(names.to.update, collapse = ", ")
                 )
                 for (name in names.to.update) {
+                    ## check if the default value or the given new value are NA
+                    ## if only one of both is NA that means that the value has to be changed
                     if (is.na(private[["attributes"]][[name]][["default"]]) && !is.na(updated.values[[name]]) ||
                         !is.na(private[["attributes"]][[name]][["default"]]) && is.na(updated.values[[name]])) {
                         private[["attributes"]][[name]][["value"]] = updated.values[[name]]
-                    } else if (is.na(private[["attributes"]][[name]][["default"]]) && is.na(updated.values[[name]])) {
+                    } ## if the default value and the given value are the same and if the 'value' field is present
+                      ## then reset the 'value' field
+                    else if (is.na(private[["attributes"]][[name]][["default"]]) && is.na(updated.values[[name]]) ||
+                               all(updated.values[[name]] == private[["attributes"]][[name]][["default"]])) {
                         if ("value" %in% names(private[["attributes"]][[name]])) {
                             private[["attributes"]][[name]][["value"]] = NULL
                         }
-                    } else {
-                        if (all(updated.values[[name]] == private[["attributes"]][[name]][["default"]])) {
-                            if ("value" %in% names(private[["attributes"]][[name]])) {
-                                private[["attributes"]][[name]][["value"]] = NULL
-                            }
-                        } else {
-                            private[["attributes"]][[name]][["value"]] = updated.values[[name]]
-                        }
+                    } ## otherwise proceed with updating the value
+                    else {
+                        private[["attributes"]][[name]][["value"]] = updated.values[[name]]
                     }
                 }
             } else {

--- a/util-conf.R
+++ b/util-conf.R
@@ -15,7 +15,7 @@
 ## Copyright 2016 by Wolfgang Mauerer <wolfgang.mauerer@oth-regensburg.de>
 ## Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 ## Copyright 2017-2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
-## Copyright 2020 by Christian Hechtl <hechtl@cs.uni-saarland.de>
+## Copyright 2020-2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2017-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
 ## Copyright 2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
@@ -259,7 +259,22 @@ Conf = R6::R6Class("Conf",
                     paste(names.to.update, collapse = ", ")
                 )
                 for (name in names.to.update) {
-                    private[["attributes"]][[name]][["value"]] = updated.values[[name]]
+                    if (is.na(private[["attributes"]][[name]][["default"]]) && !is.na(updated.values[[name]]) ||
+                        !is.na(private[["attributes"]][[name]][["default"]]) && is.na(updated.values[[name]])) {
+                        private[["attributes"]][[name]][["value"]] = updated.values[[name]]
+                    } else if (is.na(private[["attributes"]][[name]][["default"]]) && is.na(updated.values[[name]])) {
+                        if ("value" %in% names(private[["attributes"]][[name]])) {
+                            private[["attributes"]][[name]][["value"]] = NULL
+                        }
+                    } else {
+                        if (all(updated.values[[name]] == private[["attributes"]][[name]][["default"]])) {
+                            if ("value" %in% names(private[["attributes"]][[name]])) {
+                                private[["attributes"]][[name]][["value"]] = NULL
+                            }
+                        } else {
+                            private[["attributes"]][[name]][["value"]] = updated.values[[name]]
+                        }
+                    }
                 }
             } else {
                 logging::logwarn(

--- a/util-core-peripheral.R
+++ b/util-core-peripheral.R
@@ -902,8 +902,15 @@ get.author.class.issue.created.count = function(proj.data, result.limit = NULL,
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
 ## Role stability ----------------------------------------------
 
-## Get a data frame with the authors and their occurence count in the specified class for
-## the specified author classification list.
+#' Get a data frame with the authors and their occurence count in the specified class for
+#' the specified author classification list.
+#'
+#' @param author.class.overview the list of classifications in which to find the number
+#'                              of occurences
+#' @param class the type of class to look for. Can either be \code{"both"}, \code{"core},
+#'              or \code{"peripheral}. [default: "both"]
+#'
+#' @return a data frame with the authors and their occurence count in the specified class
 get.recurring.authors = function(author.class.overview, class = c("both", "core", "peripheral")) {
     logging::logdebug("get.recurring.authors: starting.")
 
@@ -971,9 +978,15 @@ get.recurring.authors = function(author.class.overview, class = c("both", "core"
     return(data)
 }
 
-## Retrieves all authors which will be classified as core by the specified
-## classification in more than a certain number of version ranges
-## -> see: "LONGTERM.CORE.THRESHOLD".
+#' Retrieves all authors which will be classified as core by the specified
+#' classification in more than a certain number of version ranges.
+#'
+#' @param author.class the author classification to use for finding the
+#'                     longterm core-authors [default: NULL]
+#'
+#' @return the names of the longterm core-authors
+#'
+#' @seealso LONGTERM.CORE.THRESHOLD
 get.longterm.core.authors = function(author.class = NULL) {
     logging::logdebug("get.longterm.core.authors: starting.")
 
@@ -995,8 +1008,13 @@ get.longterm.core.authors = function(author.class = NULL) {
     return(longterm.core)
 }
 
-## Get a markov chain object representing the role stability of the
-## specified classification overview.
+#' Get a markov chain object representing the role stability of the
+#' specified classification overview.
+#'
+#' @param author.class.overview the list of author classifications to
+#'                              use for the role stability calculation
+#'
+#' @return a markov chain object representing the role stability
 get.role.stability = function(author.class.overview) {
     logging::logdebug("get.role.stability: starting.")
 
@@ -1078,7 +1096,13 @@ get.role.stability = function(author.class.overview) {
     return(roles.stability)
 }
 
-## Calculates the cohen's kappa to measure the agreement of the specified author classifications.
+#' Calculates the cohen's kappa to measure the agreement of the specified author classifications.
+#'
+#' @param author.classification.list the first author classification list to compare
+#' @param other.author.classification.list the second author classification list to compare
+#'
+#' @return the cohens kappa coefficient describing the agreement of the two classification
+#'         lists
 calculate.cohens.kappa = function(author.classification.list, other.author.classification.list) {
     logging::logdebug("calculate.cohens.kappa: starting.")
 

--- a/util-core-peripheral.R
+++ b/util-core-peripheral.R
@@ -55,11 +55,11 @@ LONGTERM.CORE.THRESHOLD = 0.5
 ## Mapping of the classification metric to its type which can either
 ## be 'network' of 'count' based types
 CLASSIFICATION.METRIC.TO.TYPE = list(
-    "network.degree" = "network",
-    "network.eigen"   = "network",
-    "network.hierarchy"  = "network",
-    "commit.count" = "count",
-    "loc.count" = "count"
+    "network.degree"    = "network",
+    "network.eigen"     = "network",
+    "network.hierarchy" = "network",
+    "commit.count"      = "count",
+    "loc.count"         = "count"
 )
 
 
@@ -934,7 +934,8 @@ calculate.cohens.kappa = function(author.classification.list, other.author.class
 #' @param result.limit the maximum number of authors contained in the classification result. Only the top
 #'                     \code{result.limit} authors of the classification stack will be contained within the returned
 #'                     classification result. \code{NULL} means that all authors will be returned. [default: NULL]
-#' @param classification.metric.type the type of classification metric used for the classification of authors
+#' @param classification.metric.type the type of classification metric used for the classification of authors.
+#'                                   These metrics can either be count- or network-based metrics. [default: NULL]
 #'
 #' @return the classification result, that is, a list containing two named list members "core" and "peripheral", each of
 #'         which containing the authors classified as core or peripheral, respectively. Both entries in this list
@@ -943,6 +944,11 @@ calculate.cohens.kappa = function(author.classification.list, other.author.class
 get.author.class = function(author.data.frame, calc.base.name, result.limit = NULL,
                             classification.metric.type = NULL) {
     logging::logdebug("get.author.class: starting.")
+
+    if (is.null(classification.metric.type)) {
+        logging::logerror("A classification metric type has to be specified! Stopping...")
+        stop("Stopped due to missing classification metric type.")
+    }
 
     ## Make sure that we have enough data for a classification
     if (ncol(author.data.frame) < 2) {
@@ -1017,12 +1023,12 @@ get.author.class = function(author.data.frame, calc.base.name, result.limit = NU
 #' sum and multiplying with \code{CORE.THRESHOLD} which, for instance, could be 0.8, we end up with a classification
 #' threshold of (1 + 2 + 2) * 0.8 = 4. The smallest group of authors that together has a centrality sum of 4 or more
 #' could now be considered core (here, B and C with 2 commits each). Accordingly, when using a network-based approach,
-#' the threshold would now be 2 as this is the 80% quantile
+#' the threshold would now be 2 as this is the 80% quantile.
 #'
 #' @param centrality.list a list containing centrality values
 #' @param classification.metric.type the type of centrality metric used as there are two ways to determine
-#'             the threshold based on the type of centrality function. The two types are network-based and
-#'             count-based functions.[default: network]
+#'                                   the threshold based on the type of centrality function. The two types
+#'                                   are network-based and count-based functions.[default: network]
 #'
 #' @return the threshold used within classifications
 get.threshold = function(centrality.list, classification.metric.type = c("network", "count")) {
@@ -1033,7 +1039,7 @@ get.threshold = function(centrality.list, classification.metric.type = c("networ
     if (type == "network") {
         ## Calculate the quantile specified by CORE.THRESHOLD
         data.threshold = quantile(centrality.list, CORE.THRESHOLD)
-    } else {
+    } else { # type == 'count'
         ## Calculate the sum of the provided data as base for the threshold calculation
         data.threshold.base = sum(centrality.list)
 


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [X] I adhere to the coding conventions (described [here](https://github.com/se-passau/coronet/blob/master/CONTRIBUTING.md)) in my code.
- [X] I have updated the copyright headers of the files I have modified.
- [X] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [X] I have put signed-off tags in *all* commits.
- [X] I have updated the changelog file [NEWS.md](https://github.com/se-passau/coronet/blob/master/NEWS.md) appropriately.
- [X] The pull request is opened against the branch `dev`.

### Description

With this pull request we add a new threshold calculation for classifications of authors using network-based centrality values. This relates to Issue #205. The new threshold calculation uses the `CORE.THRESHOLD`% quantile of the centrality values to better represent the core and peripheral groups of the corresponding project.

When fixing this issue, we noticed that in some other unrelated tests we are cloning `ProjectData` objects using the `clone()` method of R6 but without the parameter `deep` set to `TRUE`. So we only cloned the `ProjectData` object but not the `ProjectConf` object within. Fixing this led to the problem that a `Conf` object of any kind that gets a parameter changed once and then changed back to the default value, is not the same as a `Conf` object that never changed the default. This is unintended behaviour so it gets fixed with this pull request.

Moreover, when touching `util-core-peripheral.R` anyways, we decided to work on fixing the open issues from #70. This includes changes to the code corresponding to the coding conventions, documentation fixes, and the addition of new count-based classification types for the classification of developers.

### Changelog

Added:
- Add support for classifying developers on the basis of more count-based classification metrics, including mail-count, mail-thread count, issue-count, issue-comment count, issue-commented-in count, and issue-created count: d7b2455ece9840caba7c3a46704d2a62a11bee57, 6f737c8859519867928acc4e545c89bfd91b1e2e

Changed/Improved:
- Change the threshold calculation for the classification of developers to use a quantile approach when classifying on the basis of network centrality metrics: 5128252572ab6471a9dd5437360232622c33e958
- Improve the documentation in `util-core-peripheral.R` by adding roxygen skeleton documentation to undocumented functions: a3d5ca7a5f8c021e0bed588219321798388790ac, 6f737c8859519867928acc4e545c89bfd91b1e2e
- Change the `$` notation to the bracket notation in `util-core-peripehral.R`: 6f737c8859519867928acc4e545c89bfd91b1e2e

Fixed:
- Fix the data tests in `test-data.R` to use deep clones of `ProjectData` objects: d75373a56d9de9da3bd6d6f08c1bba0ed10b8425
- Fix the `update.values()` function in `util-conf.R` to delete the `value` field if the new value is equal to the default value as the comparison of two otherwise equal `Conf` objects fails without this: d75373a56d9de9da3bd6d6f08c1bba0ed10b8425
