### PR TITLE
Add check to get.first.activity.data to look for missing activity types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 ### Fixed
 - Fix values in test for the eigenvector centrality as igraph has changed the calculation of this with version 1.2.7. Also put a warning that we recommend version 1.2.7 in `install.R` and document it in the `README.md`.(25fb86277c7cc15b94ca0327bff4bb7e818ca09b)
 - Fix the filtering of the deleted user in `util-read.R` to always be lowercase as the deleted user can appear with different spellings (#214, 1b4072c7ec0e33a595e31d9e9d27bb5c133b1556)
-
+- Add check to `get.first.activity.data` to look for missing activity types. If no activities are in the RangeData, the function will print a warning and return an empty list (PR #220, #217, 5dc975f51320fd80b79f533d9a86a1916a0562a2, 01f43a82777ded0a639d6089b2c884407e1a2af1, f3c6c305edb1a524abf70f40e8cdf0559e5c9798)
 
 ## 4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 ### Fixed
 - Fix values in test for the eigenvector centrality as igraph has changed the calculation of this with version 1.2.7. Also put a warning that we recommend version 1.2.7 in `install.R` and document it in the `README.md`.(25fb86277c7cc15b94ca0327bff4bb7e818ca09b)
 - Fix the filtering of the deleted user in `util-read.R` to always be lowercase as the deleted user can appear with different spellings (#214, 1b4072c7ec0e33a595e31d9e9d27bb5c133b1556)
-- Add check to `get.first.activity.data` to look for missing activity types. If no activities are in the RangeData, the function will print a warning and return an empty list (PR #220, #217, 5dc975f51320fd80b79f533d9a86a1916a0562a2, 01f43a82777ded0a639d6089b2c884407e1a2af1, f3c6c305edb1a524abf70f40e8cdf0559e5c9798)
+- Add check to `get.first.activity.data` to look for missing activity types. If no activities are in the RangeData, the function will print a warning and return an empty list (PR #220, #217, 5707517600c5579095c245b63c745d01cde02799, 42a4befb36e7fd9830924dc7fb2e04ecdf86e209,  d6424c03baff05562448df1b6b87828ca9a37b88, ca8a1b4c628261dcb471e1da3603439e75e4cc56, f6553c6106e5fec3837c6edb906a4d0960c5c5fb)
 
 ## 4.0
 

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -1484,9 +1484,7 @@ test_that("Test get.first.activity.data with missing commits and mails for all a
                                        bins = c(timestamps[["start"]][[1]], timestamps[["end"]][[1]]),
                                        split.basis = c("issues"))[[1]]
 
-    ## assert that warnings are thrown for the missing data sources (making the test pass instead of result in warning).
-    ## here, using '=' instead of '<-' leads to an error.
-    expect_warning(first.activity.data <- get.first.activity.data(range.data))
+    first.activity.data = get.first.activity.data(range.data)
 
     ## leave the authors without any data out
     expected.activity.data = list(

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -19,7 +19,7 @@
 ## Copyright 2018-2019 by Klara Schlüter <schluete@fim.uni-passau.de>
 ## Copyright 2018-2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
-## Copyright 2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
+## Copyright 2021-2022 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -839,7 +839,6 @@ test_that("Test add.vertex.attribute.issue.comment.count", {
     })
 })
 
-
 #' Test the add.vertex.attribute.author.email method
 test_that("Test add.vertex.attribute.author.email", {
 
@@ -1406,4 +1405,58 @@ test_that("Test addition of attributes despite of non-captured vertices", {
     expect_true("commit.count.committer.and.author" %in% igraph::list.vertex.attributes(net.commit.count))
     expect_identical(igraph::get.vertex.attribute(net.commit.count, "commit.count.committer.and.author"), 0L)
 
+})
+
+
+## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
+## Unit tests for helper functions------------------------------------------
+#' Test addition of attributes despite of non-captured vertices
+test_that("Test get.first.activity.data with missing commits and mails", {
+
+    ## initialize a ProjectData object with the ProjectConf
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data.base = ProjectData$new(project.conf = proj.conf)
+
+    ## create a RangeData object with the same data sources as proj.data.base
+    ## here, some data is already missing; this is used to test whether the function correctly sets missing data as 'NA'
+    ## lists
+    timestamps = proj.data.base$get.data.timestamps(outermost = TRUE)
+    range.data = split.data.time.based(proj.data.base, bins =
+                                                c(timestamps[["start"]][[1]], timestamps[["end"]][[1]]))[[1]]
+
+    first.activity.data = get.first.activity.data(range.data)
+
+    expected.activity.data = list(
+        list(commits = get.date.from.string("2016-07-12 15:58:59"),
+             mails = get.date.from.string("2004-10-09 18:38:13"),
+                     issues = get.date.from.string("2013-05-05 21:46:30")),
+        list(commits = get.date.from.string("2016-07-12 16:00:45"),
+             mails = get.date.from.string(" 2016-07-12 15:58.50"),
+                    issues = get.date.from.string("2013-05-25 03:25:06")),
+        list(commits = get.date.from.string("2016-07-12 16:06:32"),
+             mails = get.date.from.string("2016-07-12 16:04:40"),
+             issues = get.date.from.string("2013-04-21 23:52:09")),
+        list(commits = get.date.from.string(NA),
+             mails = get.date.from.string("2010-07-12 11:05:35"),
+             issues = get.date.from.string(NA)),
+        list(commits = get.date.from.string(NA),
+             mails = get.date.from.string("2010-07-12 12:05:34"),
+             issues = get.date.from.string(NA)),
+        list(commits = get.date.from.string(NA),
+             mails = get.date.from.string("2010-07-12 12:05:40"),
+             issues = get.date.from.string(NA)),
+        list(commits = get.date.from.string(NA),
+             mails = get.date.from.string("2010-07-12 10:05:36"),
+             issues = get.date.from.string(NA)),
+        list(commits = get.date.from.string(NA),
+             mails = get.date.from.string(NA),
+             issues = get.date.from.string("2016-07-12 15:59:59")),
+        list(commits = get.date.from.string(NA),
+             mails = get.date.from.string(NA),
+             issues = get.date.from.string("2016-07-15 20:07:47"))
+    )
+    names(expected.activity.data) = c("Björn", "Olaf", "Thomas", "Fritz fritz@example.org", "georg", "Hans",
+                                      "udo", "Karl", "Max")
+
+    expect_equal(first.activity.data, expected.activity.data)
 })

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -1410,53 +1410,101 @@ test_that("Test addition of attributes despite of non-captured vertices", {
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
 ## Unit tests for helper functions------------------------------------------
-#' Test addition of attributes despite of non-captured vertices
-test_that("Test get.first.activity.data with missing commits and mails", {
+
+#' Test get.first.activity.data with missing commits, mails, and issues.
+#' Not all authors are expected to have activities in all data sources
+test_that("Test get.first.activity.data with missing commits, mails, and issues", {
 
     ## initialize a ProjectData object with the ProjectConf
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
     proj.data.base = ProjectData$new(project.conf = proj.conf)
 
-    ## create a RangeData object with the same data sources as proj.data.base
-    ## here, some data is already missing; this is used to test whether the function correctly sets missing data as 'NA'
-    ## lists
+    ## create a RangeData object with the same data sources as 'proj.data.base'.
+    ## some data is already missing; this is used to test whether the function correctly sets missing data as 'NA'.
     timestamps = proj.data.base$get.data.timestamps(outermost = TRUE)
-    range.data = split.data.time.based(proj.data.base, bins =
-                                                c(timestamps[["start"]][[1]], timestamps[["end"]][[1]]))[[1]]
+    range.data = split.data.time.based(proj.data.base,
+                                       bins = c(timestamps[["start"]][[1]], timestamps[["end"]][[1]]))[[1]]
 
     first.activity.data = get.first.activity.data(range.data)
 
     expected.activity.data = list(
-        list(commits = get.date.from.string("2016-07-12 15:58:59"),
-             mails = get.date.from.string("2004-10-09 18:38:13"),
-                     issues = get.date.from.string("2013-05-05 21:46:30")),
-        list(commits = get.date.from.string("2016-07-12 16:00:45"),
-             mails = get.date.from.string(" 2016-07-12 15:58.50"),
-                    issues = get.date.from.string("2013-05-25 03:25:06")),
-        list(commits = get.date.from.string("2016-07-12 16:06:32"),
-             mails = get.date.from.string("2016-07-12 16:04:40"),
-             issues = get.date.from.string("2013-04-21 23:52:09")),
-        list(commits = get.date.from.string(NA),
-             mails = get.date.from.string("2010-07-12 11:05:35"),
-             issues = get.date.from.string(NA)),
-        list(commits = get.date.from.string(NA),
-             mails = get.date.from.string("2010-07-12 12:05:34"),
-             issues = get.date.from.string(NA)),
-        list(commits = get.date.from.string(NA),
-             mails = get.date.from.string("2010-07-12 12:05:40"),
-             issues = get.date.from.string(NA)),
-        list(commits = get.date.from.string(NA),
-             mails = get.date.from.string("2010-07-12 10:05:36"),
-             issues = get.date.from.string(NA)),
-        list(commits = get.date.from.string(NA),
-             mails = get.date.from.string(NA),
-             issues = get.date.from.string("2016-07-12 15:59:59")),
-        list(commits = get.date.from.string(NA),
-             mails = get.date.from.string(NA),
-             issues = get.date.from.string("2016-07-15 20:07:47"))
+        "Björn" = list(commits = get.date.from.string("2016-07-12 15:58:59"),
+                       mails = get.date.from.string("2004-10-09 18:38:13"),
+                       issues = get.date.from.string("2013-05-05 21:46:30")),
+        "Olaf" = list(commits = get.date.from.string("2016-07-12 16:00:45"),
+                      mails = get.date.from.string("2016-07-12 15:58:50"),
+                      issues = get.date.from.string("2013-05-25 03:25:06")),
+        "Thomas" = list(commits = get.date.from.string("2016-07-12 16:06:32"),
+                        mails = get.date.from.string("2016-07-12 16:04:40"),
+                        issues = get.date.from.string("2013-04-21 23:52:09")),
+        "Fritz fritz@example.org" = list(commits = get.date.from.string(NA),
+                                         mails = get.date.from.string("2010-07-12 11:05:35"),
+                                         issues = get.date.from.string(NA)),
+        "georg" = list(commits = get.date.from.string(NA),
+                       mails = get.date.from.string("2010-07-12 12:05:34"),
+                       issues = get.date.from.string(NA)),
+        "Hans" = list(commits = get.date.from.string(NA),
+                      mails = get.date.from.string("2010-07-12 12:05:40"),
+                      issues = get.date.from.string(NA)),
+        "udo" = list(commits = get.date.from.string(NA),
+                     mails = get.date.from.string("2010-07-12 10:05:36"),
+                     issues = get.date.from.string(NA)),
+        "Karl" = list(commits = get.date.from.string(NA),
+                      mails = get.date.from.string(NA),
+                      issues = get.date.from.string("2016-07-12 15:59:59")),
+        "Max" = list(commits = get.date.from.string(NA),
+                      mails = get.date.from.string(NA),
+                      issues = get.date.from.string("2016-07-15 20:07:47"))
     )
-    names(expected.activity.data) = c("Björn", "Olaf", "Thomas", "Fritz fritz@example.org", "georg", "Hans",
-                                      "udo", "Karl", "Max")
+
+    expect_equal(first.activity.data, expected.activity.data)
+})
+
+#' Test get.first.activity.data with missing commits and mails for all authors
+test_that("Test get.first.activity.data with missing commits and mails for all authors", {
+
+    ## initialize a ProjectData object with the ProjectConf
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data = ProjectData$new(project.conf = proj.conf)
+
+    ## get the timestamps for splitting before discarding the data
+    timestamps = proj.data$get.data.timestamps(outermost = TRUE)
+
+    ## clear commit and mail data completely so that all authors have neither any commits nor mails left
+    proj.data$set.commits(create.empty.commits.list())
+    proj.data$set.mails(create.empty.mails.list())
+
+    ## also lock the data sources in order to prevent reloading the data when calling the getters
+    proj.conf$update.value("commits.locked", TRUE)
+    proj.conf$update.value("mails.locked", TRUE)
+
+    ## create a RangeData object with the same data sources as 'proj.data.base'.
+    ## some data is already missing; this is used to test whether the function correctly sets missing data as 'NA'.
+    range.data = split.data.time.based(proj.data,
+                                       bins = c(timestamps[["start"]][[1]], timestamps[["end"]][[1]]),
+                                       split.basis = c("issues"))[[1]]
+
+    ## assert that warnings are thrown for the missing data sources (making the test pass instead of result in warning).
+    ## here, using '=' instead of '<-' leads to an error.
+    expect_warning(first.activity.data <- get.first.activity.data(range.data))
+
+    ## leave the authors without any data out
+    expected.activity.data = list(
+        "Björn" = list(commits = get.date.from.string(NA),
+                       mails = get.date.from.string(NA),
+                       issues = get.date.from.string("2013-05-05 21:46:30")),
+        "Karl" = list(commits = get.date.from.string(NA),
+                      mails = get.date.from.string(NA),
+                      issues = get.date.from.string("2016-07-12 15:59:59")),
+        "Max" = list(commits = get.date.from.string(NA),
+                     mails = get.date.from.string(NA),
+                     issues = get.date.from.string("2016-07-15 20:07:47")),
+        "Olaf" = list(commits = get.date.from.string(NA),
+                      mails = get.date.from.string(NA),
+                      issues = get.date.from.string("2013-05-25 03:25:06")),
+        "Thomas" = list(commits = get.date.from.string(NA),
+                        mails = get.date.from.string(NA),
+                        issues = get.date.from.string("2013-04-21 23:52:09")))
 
     expect_equal(first.activity.data, expected.activity.data)
 })

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -1030,9 +1030,9 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
         return(list())
     }
 
-    ## check for keys whose member lists are not empty or na
+    ## check for keys whose member lists are empty or NA
     missing.keys = activity.types[is.na(activity.by.type[activity.types]) |
-                                      length(activity.by.type[activity.types]) == 0]
+                                  length(activity.by.type[activity.types]) == 0]
     ## get the keys that contain valid data for finding a candidate for copying lists from to replace the missing keys
     present.keys = setdiff(activity.types, missing.keys)
 

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -1017,6 +1017,7 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
                 m = list(min(x[["date"]]))
                 ## add activity type as name to the list
                 names(m) = type
+
                 return(m)
             }
         )
@@ -1031,8 +1032,13 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
     }
 
     ## check for keys whose member lists are empty or NA
-    missing.keys = activity.types[is.na(activity.by.type[activity.types]) |
-                                  length(activity.by.type[activity.types]) == 0]
+    ## first, get a logical vector indicating all missing keys
+    missing.keys = sapply(activity.types, function(x) {
+        is.na(activity.by.type[[x]]) || length(activity.by.type[[x]]) == 0
+    })
+    ## then apply this vector to the 'activity.types' vector in order to pick the actual keys
+    missing.keys = activity.types[missing.keys]
+
     ## get the keys that contain valid data for finding a candidate for copying lists from to replace the missing keys
     present.keys = setdiff(activity.types, missing.keys)
 

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -1057,7 +1057,7 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
     })
 
     for (missing.key in missing.keys) {
-        logging::logwarn(paste("The type", missing.key, "was configured but the RangeData did not cotain any",
+        logging::logwarn(paste("The type", missing.key, "was configured but the RangeData did not contain any",
                                  "activities of that type"), sep = " ")
         activity.by.type[missing.key] = na.list
     }

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -1022,9 +1022,10 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
         )
         return(minima.per.person)
     })
+    names(activity.by.type) = activity.types
 
     ## if activity.by.type is null or the list is empty, print a warning and return an empty list
-    if (is.null(activity.by.type) | length(activity.by.type) == 0) {
+    if (is.null(activity.by.type) || length(activity.by.type) == 0) {
         logging::logwarn("There were no activities in the given RangeData at all")
         return(list())
     }
@@ -1043,7 +1044,7 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
     ## for the configured activity types
     if (length(present.keys) == 0 || is.null(present.keys)) {
         logging::logwarn("There were no activities in the given RangeData that were configured")
-        return(list())
+        return(list(NA))
     }
 
     ## else, take the first present item, copy its list and replace all entries with NA so that the reduce and apply

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -1051,7 +1051,10 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
 
     ## else, take the first present item, copy its list and replace all entries with NA so that the reduce and apply can
     ## work it out
-    na.list = lapply(activity.by.type[present.keys[[1]]], function(x) return(NA))
+    na.list = lapply(activity.by.type[present.keys[[1]]], function(x) {
+        authors = lapply(x, function(author) return(NA))
+        return(authors)
+    })
 
     for (missing.key in missing.keys) {
         logging::logwarn(paste(c("The type", missing.key, "was configured but the RangeData did not cotain any",

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -1057,8 +1057,8 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
     })
 
     for (missing.key in missing.keys) {
-        logging::logwarn(paste(c("The type", missing.key, "was configured but the RangeData did not cotain any",
-                                 "activities of that type"), sep = " "))
+        logging::logwarn(paste("The type", missing.key, "was configured but the RangeData did not cotain any",
+                                 "activities of that type"), sep = " ")
         activity.by.type[missing.key] = na.list
     }
 

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -19,6 +19,7 @@
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2020 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
+## Copyright 2022 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
@@ -1019,6 +1020,26 @@ get.first.activity.data = function(range.data, activity.types = c("commits", "ma
         )
         return(minima.per.person)
     })
+
+    ## if activity.by.type is null, print a warning and return an empty list
+    if (is.null(activity.by.type)) {
+        logging::logwarn('There were no activities in the given RangeData')
+        return(list())
+    }
+
+    ## for each missing activity type add it with together with a copy of
+    ## any other key but with the author lists set to NA;
+    ## additionally, print a warning
+    missing.keys = setdiff(names(activity.by.type), activity.types)
+    present.key = intersect(names(activity.by.type), activity.types)[[1]]
+    na.list = lapply(activity.by.type[present.key], function (x) NA)
+
+    for (missing.key in missing.keys) {
+        logging::logwarn(paste(c('The type', missing.key, 'was configured',
+                                 'but the RangeData did not cotain any',
+                                 'activities of that type'), sep = ' '))
+        activity.by.type[missing.key] = na.list
+    }
 
     ## accumulate/fold lists 'activity.by.type' by adding all values of each list
     ## to an intermediate list (start with first list); for example:

--- a/util-read.R
+++ b/util-read.R
@@ -14,7 +14,7 @@
 ## Copyright 2016-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 ## Copyright 2017-2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
-## Copyright 2020-2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
+## Copyright 2020-2022 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2017-2018 by Thomas Bock <bockthom@fim.uni-passau.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
@@ -541,8 +541,11 @@ read.gender = function(data.path) {
     file = file.path(data.path, "gender.list")
 
     ## read data.frame from disk (as expected from save.list.to.file) [can be empty]
+    ## comment char is set to empty string as the names of developers can contain the
+    ## char '#'. This does not affect the other data sources as all names there are
+    ## in "".
     gender.data = try(read.table(file, header = FALSE, sep = ";", strip.white = TRUE,
-                                 encoding = "UTF-8"), silent = TRUE)
+                                 encoding = "UTF-8", comment.char = ""), silent = TRUE)
 
 
     ## handle the case if the list of items is empty


### PR DESCRIPTION
Adresses issue #217

Signed-off-by: Niklas Schneider <s8nlschn@stud.uni-saarland.de>

<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

<!-- Add a description of the added/changed/fixed functionality in this pull request. -->
Add check to `get.first.activity.data` function in `util-networks-covariates.R` to check whether there are activity types that configured but not present in the given data.

If there are no activities at all, print a warning and return an empty list immediately (this is referred to as the "quick and dirty solution" in #217...). If there are activity types missing but also some present, copy an entry from a present key, replace its elements with `NA`, and add that list for each missing key . Also print a warning in this case.

This pull request addresses #217.

