### PR TITLE
Fix CI pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
-## Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2020-2022 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 # Drone CI Setup
@@ -69,12 +69,6 @@ steps:
   commands: *runTests
   depends_on: [clone]
 
-- name: R-3.3
-  pull: if-not-exists
-  image: r-base:3.3.2
-  commands: *runTests
-  depends_on: [clone]
-
 ---
 # Pipeline "run showcase file"
 kind: pipeline
@@ -128,13 +122,6 @@ steps:
   image: r-base:3.4.4
   commands: *runShowcase
   depends_on: [clone]
-
-- name: R-3.3
-  pull: if-not-exists
-  image: r-base:3.3.2
-  commands: *runShowcase
-  depends_on: [clone]
-
 
 #trigger:
 #  branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -121,17 +121,17 @@ steps:
   commands: *runShowcase
   depends_on: [clone]
 
-- name: R-3.5
-  pull: if-not-exists
-  image: rocker/r-ver:3.5.3
-  commands: *runShowcase
-  depends_on: [clone]
-
-- name: R-3.4
-  pull: if-not-exists
-  image: rocker/r-ver:3.4.4
-  commands: *runShowcase
-  depends_on: [clone]
+#- name: R-3.5
+#  pull: if-not-exists
+#  image: rocker/r-ver:3.5.3
+#  commands: *runShowcase
+#  depends_on: [clone]
+#
+#- name: R-3.4
+#  pull: if-not-exists
+#  image: rocker/r-ver:3.4.4
+#  commands: *runShowcase
+#  depends_on: [clone]
 
 #trigger:
 #  branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -27,12 +27,17 @@ platform:
 
 steps:
 - name: R-latest
-  image: r-base:latest
+  image: rocker/r-ver:latest
   commands: &runTests
   # stop treating warnings as errors
   - unset CI
   # package dependencies
-  - apt install update -y && libudunits2-dev
+  #  - apt install update -y && libudunits2-dev
+  - apt-get update -y
+  - apt-get install --assume-yes libxml2
+  - apt-get install --assume-yes libxml2-dev
+  - apt-get install --assume-yes libglpk-dev
+  - echo 'options(repos = c(CRAN = "https://cloud.r-project.org"))' >>"/usr/local/lib/R/etc/Rprofile.site"
   # package installation
   - Rscript install.R
   # execute test suite
@@ -41,31 +46,31 @@ steps:
 
 - name: R-4.1
   pull: if-not-exists
-  image: r-base:4.1.1
+  image: rocker/r-ver:4.1.3
   commands: *runTests
   depends_on: [clone]
 
 - name: R-4.0
   pull: if-not-exists
-  image: r-base:4.0.5
+  image: rocker/r-ver:4.0.5
   commands: *runTests
   depends_on: [clone]
 
 - name: R-3.6
   pull: if-not-exists
-  image: r-base:3.6.3
+  image: rocker/r-ver:3.6.3
   commands: *runTests
   depends_on: [clone]
 
 - name: R-3.5
   pull: if-not-exists
-  image: r-base:3.5.3
+  image: rocker/r-ver:3.5.3
   commands: *runTests
   depends_on: [clone]
 
 - name: R-3.4
   pull: if-not-exists
-  image: r-base:3.4.4
+  image: rocker/r-ver:3.4.4
   commands: *runTests
   depends_on: [clone]
 
@@ -81,12 +86,17 @@ platform:
 
 steps:
 - name: R-latest
-  image: r-base:latest
+  image: rocker/r-ver:latest
   commands: &runShowcase
   # stop treating warnings as errors
   - unset CI
   # package dependencies
-  - apt install update -y && libudunits2-dev
+  #- apt install update -y && libudunits2-dev
+  - apt-get update -y
+  - apt-get install --assume-yes libxml2
+  - apt-get install --assume-yes libxml2-dev
+  - apt-get install --assume-yes libglpk-dev
+  - echo 'options(repos = c(CRAN = "https://cloud.r-project.org"))' >>"/usr/local/lib/R/etc/Rprofile.site"
   # package installation
   - Rscript install.R
   # execute showcase file
@@ -95,31 +105,31 @@ steps:
 
 - name: R-4.1
   pull: if-not-exists
-  image: r-base:4.1.0
+  image: rocker/r-ver:4.1.3
   commands: *runShowcase
   depends_on: [clone]
 
 - name: R-4.0
   pull: if-not-exists
-  image: r-base:4.0.5
+  image: rocker/r-ver:4.0.5
   commands: *runShowcase
   depends_on: [clone]
 
 - name: R-3.6
   pull: if-not-exists
-  image: r-base:3.6.3
+  image: rocker/r-ver:3.6.3
   commands: *runShowcase
   depends_on: [clone]
 
 - name: R-3.5
   pull: if-not-exists
-  image: r-base:3.5.3
+  image: rocker/r-ver:3.5.3
   commands: *runShowcase
   depends_on: [clone]
 
 - name: R-3.4
   pull: if-not-exists
-  image: r-base:3.4.4
+  image: rocker/r-ver:3.4.4
   commands: *runShowcase
   depends_on: [clone]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,9 +9,11 @@
 
 ### Changed/Improved
 - Add `mode` parameter to `metrics.vertex.degrees` to allow choosing between indegree, outdegree, and total (#219, ae14eb4cb83c6ab8f387886228cdf7ea6f3258c4)
+- Adjust `.drone.yml` CI config to prevent pipeline fails: `R` version `3.3` is not tested any more as some packages are not available any more for this `R` version (ca6b474d773c045dd88a19aee905283a373df0a6). Also another docker container in the CI pipeline is used as there are problems with the previously used docker instance (937f797ee04b78a087ea84043d075e7ca7558d70)
+
 
 ### Fixed
-- Fix values in test for the eigenvector centrality as igraph has changed the calculation of this with version 1.2.7. Also put a warning that we recommend version 1.2.7 in `install.R` and document it in the `README.md`.(25fb86277c7cc15b94ca0327bff4bb7e818ca09b)
+- Fix values in test for the eigenvector centrality as igraph has changed the calculation of this with version 1.2.7. Also put a warning that we recommend version 1.3.0 in `install.R` and document it in the `README.md` (25fb86277c7cc15b94ca0327bff4bb7e818ca09b, 1bcbca96d6dbaa2d4a28e830da963604682eac70)
 - Fix the filtering of the deleted user in `util-read.R` to always be lowercase as the deleted user can appear with different spellings (#214, 1b4072c7ec0e33a595e31d9e9d27bb5c133b1556)
 - Add check to `get.first.activity.data` to look for missing activity types. If no activities are in the RangeData, the function will print a warning and return an empty list (PR #220, #217, 5707517600c5579095c245b63c745d01cde02799, 42a4befb36e7fd9830924dc7fb2e04ecdf86e209,  d6424c03baff05562448df1b6b87828ca9a37b88, ca8a1b4c628261dcb471e1da3603439e75e4cc56, f6553c6106e5fec3837c6edb906a4d0960c5c5fb)
 
@@ -28,7 +30,7 @@
 - Add function `get.data.sources.from.relations` to `util-networks.R` which extracts the data sources of a network that were used when building it (PR #195, d1e4413a49ab83a115a7f26719592876371ab264)
 - Add tests for the `get.data.sources.from.relations` function (PR #195, add0c746dde8279da41d180deecf52b91a46095c)
 - Add logo directory containing several logo variants (PR #196, 82f99719b8a43b0a44914b67b26bf1a34bb076c6, dc4659ea354e97159f8ee6167811db544f0b7087, fdc5e677325225f92d1f99948cb9441bfe1d150d, 752a9b376ffeffd5d6b380b4fdba838a890e3ef7)
-- Add function `preprocess.issue.data`, which implements common issue data filtering operations. (fcf5cee64c809d62a33275cbd3272b8087869eea, a566caec6d7e649cc495d292a19eca8a7ffccde8, 5ba6feb988c44e2ba398bccce6c88e69d3bb552e)
+- Add function `preprocess.issue.data`, which implements common issue data filtering operations (fcf5cee64c809d62a33275cbd3272b8087869eea, a566caec6d7e649cc495d292a19eca8a7ffccde8, 5ba6feb988c44e2ba398bccce6c88e69d3bb552e)
 - Add function `get.issues.uncached`, which gets the issues filtered without poisoning or using the cache. (eb919fad9519d6e1a23261977bb3bfa2b899aaf9)
 - Add function `get.issues.unfiltered` to get the unfiltered issues so that these methods follow the naming scheme known from the respective methods for commits (b9dd94c8575b8cab40d0d1185368854f84299d87, e05f3448e1e2e8faaac219ed4ac818f82f3d8ff7)
 - Add per-author vertex attributes regarding counting of issues, issue-creations, issue-comments, mails, mail-threads, ... (like mail thread count, issue creation count) (PR #194, issue #188, 9f9150a97ffbb64607df0ddcbce299e16c2580da, 7260d62cf6f1470584753f76970d19664638eeed, 139f70b67903909bcd4c57e26afa458681a869f2, eb4f649c04155e22195627072e0f08bb8fe65dc4, 627873c641410182ca8fee0e78b95d7bda1e8e6b, 1e1406f4a0898cac3e61a7bc9a5aa665dceef79f, 98e11abc651b5fe0ec994eddea078635b0d6f0b2, a566caec6d7e649cc495d292a19eca8a7ffccde8)

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ While using the package, we require the following infrastructure.
 
 #### [`R`](https://www.r-project.org/)
 
-Minimum requirement is `R` version `3.3.1`. Hence, later `R` versions also work.
+Minimum requirement is `R` version `3.4.4`. Hence, later `R` versions also work. (Earlier `R` versions beginning from version `3.3.1` on should also work, but some packages are not available any more for these versions, so we do not test them any more in our CI pipeline.)
 
-We currently recommend version `4.1.1` or `3.6.3` for reliability reasons and `packrat` compatibility, but also later `R` versions should work (and are tested using our CI script).
+We currently *recommend* `R` version `4.1.1` or `3.6.3` for reliability reasons and `packrat` compatibility, but also later `R` versions should work (and are tested using our CI script).
 
 #### [`packrat`](http://rstudio.github.io/packrat/) (recommended)
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Alternatively, you can run `Rscript install.R` to install the packages.
 
 - `yaml`: To read YAML configuration files (i.e., Codeface configuration files)
 - `R6`: For proper classes
-- `igraph`: For the construction of networks (package version `1.2.7` or higher is recommended)
+- `igraph`: For the construction of networks (package version `1.3.0` or higher is recommended)
 - `plyr`: For the `dlply` splitting-function and `rbind.fill`
 - `parallel`: For parallelization
 - `logging`: Logging

--- a/install.R
+++ b/install.R
@@ -16,6 +16,7 @@
 ## Copyright 2015 by Wolfgang Mauerer <wolfgang.mauerer@oth-regensburg.de>
 ## Copyright 2015-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2022 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 ## Copyright 2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
@@ -65,7 +66,7 @@ if (length(p) > 0) {
     install.packages(p, dependencies = NA, verbose = TRUE, quiet = TRUE)
 
     igraph.version = installed.packages()[rownames(installed.packages()) == "igraph", "Version"]
-    if (compareVersion(igraph.version, "1.2.7") == -1) {
-        print("WARNING: igraph version 1.2.7 or higher is recommended for using coronet.")
+    if (compareVersion(igraph.version, "1.3.0") == -1) {
+        print("WARNING: igraph version 1.3.0 or higher is recommended for using coronet.")
     }
 }

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -14,6 +14,7 @@
 ## Copyright 2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2022 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2019 by Christian Hechtl <hechtl@fim.uni-passau.de>
 ## Copyright 2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## All Rights Reserved.
@@ -76,6 +77,28 @@ test_that("Eigenvector classification", {
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
     row.names(result$core) = NULL
+    row.names(result$peripheral) = NULL
+
+    #expect_equal(expected, result, tolerance = 0.0001)
+    # TODO: Find a way to directly test for equality without the need of taking care of different orders of author
+    #       names. For the moment, we take the following workaround:
+
+    ## Due to floating point precision differences, values might differ and also the order of author names of
+    ## authors that have an equal centrality value are might be different. Therefore, first check for the equality
+    ## of the centrality values and the equality of the sets of authors.
+    expect_equal(expected.peripheral$eigen.centrality,
+                 result$peripheral$eigen.centrality, tolerance = 0.0001)
+    expect_setequal(expected.peripheral$author.name, result$peripheral$author.name)
+
+    ## Second, round the centrality values and alphabetically reorder rows that have an equal centrality value
+    expected.peripheral$eigen.centrality = round(expected.peripheral$eigen.centrality, 5)
+    result$peripheral$eigen.centrality = round(result$peripheral$eigen.centrality, 5)
+    expected.peripheral = expected.peripheral[order(-expected.peripheral$eigen.centrality$,
+                                                    expected.peripheral$author.name), , drop = FALSE]
+    row.names(expected.peripheral) = NULL
+    expected = list(core = expected.core, peripheral = expected.peripheral)
+    result$peripheral = result$peripheral[order(-result$peripheral$eigen.centrality,
+                                                result$peripheral$author.name), , drop = FALSE]
     row.names(result$peripheral) = NULL
     expect_equal(expected, result, tolerance = 0.0001)
 })

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -55,8 +55,8 @@ test_that("Vertex-degree classification using 'restrict.classification.to.author
     expected.peripheral = data.frame(author.name = c("Björn", "Darth Sidious"), vertex.degree = c(2, NA))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 
@@ -76,8 +76,8 @@ test_that("Eigenvector classification", {
                                                           3.925231e-17, 3.925231e-17, 3.925231e-17))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
 
     #expect_equal(expected, result, tolerance = 0.0001)
     # TODO: Find a way to directly test for equality without the need of taking care of different orders of author
@@ -86,20 +86,20 @@ test_that("Eigenvector classification", {
     ## Due to floating point precision differences, values might differ and also the order of author names of
     ## authors that have an equal centrality value are might be different. Therefore, first check for the equality
     ## of the centrality values and the equality of the sets of authors.
-    expect_equal(expected.peripheral$eigen.centrality,
-                 result$peripheral$eigen.centrality, tolerance = 0.0001)
-    expect_setequal(expected.peripheral$author.name, result$peripheral$author.name)
+    expect_equal(expected.peripheral[["eigen.centrality"]],
+                 result[["peripheral"]][["eigen.centrality"]], tolerance = 0.0001)
+    expect_setequal(expected.peripheral[["author.name"]], result[["peripheral"]][["author.name"]])
 
     ## Second, round the centrality values and alphabetically reorder rows that have an equal centrality value
-    expected.peripheral$eigen.centrality = round(expected.peripheral$eigen.centrality, 5)
-    result$peripheral$eigen.centrality = round(result$peripheral$eigen.centrality, 5)
-    expected.peripheral = expected.peripheral[order(-expected.peripheral$eigen.centrality$,
-                                                    expected.peripheral$author.name), , drop = FALSE]
+    expected.peripheral[["eigen.centrality"]] = round(expected.peripheral[["eigen.centrality"]], 5)
+    result[["peripheral"]][["eigen.centrality"]] = round(result[["peripheral"]][["eigen.centrality"]], 5)
+    expected.peripheral = expected.peripheral[order(-expected.peripheral[["eigen.centrality"]],
+                                                    expected.peripheral[["author.name"]]), , drop = FALSE]
     row.names(expected.peripheral) = NULL
     expected = list(core = expected.core, peripheral = expected.peripheral)
-    result$peripheral = result$peripheral[order(-result$peripheral$eigen.centrality,
-                                                result$peripheral$author.name), , drop = FALSE]
-    row.names(result$peripheral) = NULL
+    result[["peripheral"]] = result[["peripheral"]][order(-result[["peripheral"]][["eigen.centrality"]],
+                                                          result[["peripheral"]][["author.name"]]), , drop = FALSE]
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result, tolerance = 0.0001)
 })
 
@@ -114,8 +114,8 @@ test_that("Commit-count classification using 'result.limit'" , {
     expected.core = data.frame(author.name = c("Björn", "Olaf", "Thomas"), commit.count = c(1, 1, 1))
     expected = list(core = expected.core, peripheral = expected.core[0, ])
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 
@@ -128,8 +128,8 @@ test_that("LOC-count classification" , {
     expected.core = data.frame(author.name = c("Björn", "Olaf", "Thomas"), loc.count = c(2, 1, 1))
     expected = list(core = expected.core, peripheral = expected.core[0, ])
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 
@@ -144,8 +144,8 @@ test_that("Mail-count classification" , {
     expected.peripheral = data.frame(author.name = c("Thomas", "georg", "udo"), mail.count = c(1, 1, 1))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 
@@ -160,8 +160,8 @@ test_that("Mail-thread-count classification" , {
     expected.peripheral = data.frame(author.name = c("georg", "udo"), mail.thread.count = c(1, 1))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 
@@ -175,8 +175,8 @@ test_that("Issue-count classification" , {
     expected.peripheral = data.frame(author.name = c("Karl", "Max", "udo"), issue.count = c(1, 1, 1))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 
@@ -192,8 +192,8 @@ test_that("Issue-comment-count classification" , {
                                issue.comment.count = c(2, 1))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 
@@ -209,8 +209,8 @@ test_that("Issue-commented-in-count classification" , {
                                      issue.commented.in.count = c(1, 1))
     expected = list(core = expected.core, peripheral = expected.peripheral)
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 
@@ -224,8 +224,8 @@ test_that("Issue-created-count classification" , {
                                issue.created.count = c(1, 1, 1))
     expected = list(core = expected.core, peripheral = expected.core[0, ])
 
-    row.names(result$core) = NULL
-    row.names(result$peripheral) = NULL
+    row.names(result[["core"]]) = NULL
+    row.names(result[["peripheral"]]) = NULL
     expect_equal(expected, result)
 })
 

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -80,11 +80,11 @@ test_that("Eigenvector classification", {
     row.names(result[["peripheral"]]) = NULL
 
     expect_equal(expected, result, tolerance = 0.0001)
-    # TODO: Find a way to directly test for equality without the need of taking care of different orders of author
-    #       names. For the moment, we take the following workaround:
+    ## TODO: Find a way to directly test for equality without the need of taking care of different orders of author
+    ##       names. For the moment, we take the following workaround:
 
     ## Due to floating point precision differences, values might differ and also the order of author names of
-    ## authors that have an equal centrality value are might be different. Therefore, first check for the equality
+    ## authors that have an equal centrality value might be different. Therefore, first check for the equality
     ## of the centrality values and the equality of the sets of authors.
     expect_equal(expected.peripheral[["eigen.centrality"]],
                  result[["peripheral"]][["eigen.centrality"]], tolerance = 0.0001)

--- a/tests/test-core-peripheral.R
+++ b/tests/test-core-peripheral.R
@@ -79,7 +79,7 @@ test_that("Eigenvector classification", {
     row.names(result[["core"]]) = NULL
     row.names(result[["peripheral"]]) = NULL
 
-    #expect_equal(expected, result, tolerance = 0.0001)
+    expect_equal(expected, result, tolerance = 0.0001)
     # TODO: Find a way to directly test for equality without the need of taking care of different orders of author
     #       names. For the moment, we take the following workaround:
 


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

Some tests in our CI pipeline failed for multiple reasons:
- The steps for `R` version `3.3` failed as some of the used packages require version `3.4` in the most recent package version and are, therefore, not available any more for `3.3.`. Hence, we exclude this `R` version from the pipeline.
- The steps for `R` version `4.1` and higher failed as the used `r-base` docker container uses some buggy version of Debian which uses `glibc` version >= 2.33 which prevents R to be started within the buggy docker container. Therefore, we switched to the `r-ver` docker container in our CI pipeline to prevent this problem (and manually set the package repository to CRAN).
- Some tests regarding eigenvector centrality potentially fail on some machines do to misordering of data.frame rows due to inaccurracies in floating point operations. To have a potential fix if such a problem occurs again, we now have a workaround for this test.

Last but not least: As `igraph` has released a new package version which contains a lot of bugfixes, we now recommend to use, at least, version `1.3.0` of `igraph`.
