### PR TITLE
Make removal of empty/deleted users consistent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 ### Changed/Improved
 
 - Include structural verification to almost all functions that read dataframes from files or set a dataframe (setter-functions) (PR #231, b7a95881da72ccaa548c6cd5d94bd558a25caa6f).
+- Include removal of empty and deleted users in the setters of mails, commits, issues, and authors (PR #235, 08fbd3e11e33d060f42cbc6f729eaf60b48a6de7)
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,7 +11,7 @@
 ### Changed/Improved
 
 - Include structural verification to almost all functions that read dataframes from files or set a dataframe (setter-functions) (PR #231, b7a95881da72ccaa548c6cd5d94bd558a25caa6f).
-- Include removal of empty and deleted users in the setters of mails, commits, issues, and authors (PR #235, 08fbd3e11e33d060f42cbc6f729eaf60b48a6de7)
+- Include removal of empty and deleted users in the setters of mails, commits, issues, and authors.For commits, also the "committer.name" column is now checked for deleted or empty users. (PR #235, 08fbd3e11e33d060f42cbc6f729eaf60b48a6de7)
 
 ### Fixed
 

--- a/tests/codeface-data/results/testing/test_feature/feature/commits.list
+++ b/tests/codeface-data/results/testing/test_feature/feature/commits.list
@@ -9,5 +9,5 @@
 32716;"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"d01921773fae4bed8186b0aa411d6a2f7a6626e6";1;1;0;1;"";"";"";0
 32711;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"Base_Feature";"Feature";1
 32711;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
-32711;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"0a1a5c523d835459c40f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
-32711;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"0a1a5c523d835459c41f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+31711;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"0a1a5c523d835459c40f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+30711;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"0a1a5c523d835459c41f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1

--- a/tests/codeface-data/results/testing/test_feature/feature/commits.list
+++ b/tests/codeface-data/results/testing/test_feature/feature/commits.list
@@ -9,3 +9,5 @@
 32716;"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"d01921773fae4bed8186b0aa411d6a2f7a6626e6";1;1;0;1;"";"";"";0
 32711;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"Base_Feature";"Feature";1
 32711;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+32711;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"0a1a5c523d835459c40f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+32711;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"0a1a5c523d835459c41f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1

--- a/tests/codeface-data/results/testing/test_feature/feature/commits.list
+++ b/tests/codeface-data/results/testing/test_feature/feature/commits.list
@@ -9,5 +9,5 @@
 32716;"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"d01921773fae4bed8186b0aa411d6a2f7a6626e6";1;1;0;1;"";"";"";0
 32711;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"Base_Feature";"Feature";1
 32711;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
-31711;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"0a1a5c523d835459c40f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
-30711;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"0a1a5c523d835459c41f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+31711;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"2ef7bde608ce5404e97d5f042f95f89f1c232871";1;1;0;1;"test2.c";"foo";"Feature";1
+30711;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"c6954cb75e3eeec5b827f64e97b6a4ba187c0d55";1;1;0;1;"test2.c";"foo";"Feature";1

--- a/tests/codeface-data/results/testing/test_proximity/proximity/commits.list
+++ b/tests/codeface-data/results/testing/test_proximity/proximity/commits.list
@@ -5,5 +5,5 @@
 32715;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"File_Level";"Function";1
 32720;"2016-07-12 16:06:20";"Karl";"karl@example.org";"2016-07-12 16:06:20";"Karl";"karl@example.org";"418d1dc4929ad1df251d2aeb833dd45757b04a6f";1;1;0;1;"";"";"";0
 32721;"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"d01921773fae4bed8186b0aa411d6a2f7a6626e6";1;1;0;1;"";"";"";0
-32711;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"0a1a5c523d835459c40f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
-32711;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"0a1a5c523d835459c41f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+32811;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"0a1a5c523d835459c40f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+32911;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"0a1a5c523d835459c41f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1

--- a/tests/codeface-data/results/testing/test_proximity/proximity/commits.list
+++ b/tests/codeface-data/results/testing/test_proximity/proximity/commits.list
@@ -5,3 +5,5 @@
 32715;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"File_Level";"Function";1
 32720;"2016-07-12 16:06:20";"Karl";"karl@example.org";"2016-07-12 16:06:20";"Karl";"karl@example.org";"418d1dc4929ad1df251d2aeb833dd45757b04a6f";1;1;0;1;"";"";"";0
 32721;"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"d01921773fae4bed8186b0aa411d6a2f7a6626e6";1;1;0;1;"";"";"";0
+32711;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"0a1a5c523d835459c40f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+32711;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"0a1a5c523d835459c41f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1

--- a/tests/codeface-data/results/testing/test_proximity/proximity/commits.list
+++ b/tests/codeface-data/results/testing/test_proximity/proximity/commits.list
@@ -5,5 +5,5 @@
 32715;"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"2016-07-12 16:06:32";"Thomas";"thomas@example.org";"0a1a5c523d835459c42f33e863623138555e2526";1;1;0;1;"test2.c";"File_Level";"Function";1
 32720;"2016-07-12 16:06:20";"Karl";"karl@example.org";"2016-07-12 16:06:20";"Karl";"karl@example.org";"418d1dc4929ad1df251d2aeb833dd45757b04a6f";1;1;0;1;"";"";"";0
 32721;"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"2016-07-12 16:06:30";"Thomas";"thomas@example.org";"d01921773fae4bed8186b0aa411d6a2f7a6626e6";1;1;0;1;"";"";"";0
-32811;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"0a1a5c523d835459c40f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
-32911;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"0a1a5c523d835459c41f33e863623138555e2526";1;1;0;1;"test2.c";"foo";"Feature";1
+32811;"2016-07-12 16:06:33";"Thomas";"thomas@example.org";"2016-07-12 16:06:33";"";"thomas@example.org";"2ef7bde608ce5404e97d5f042f95f89f1c232871";1;1;0;1;"test2.c";"foo";"Feature";1
+32911;"2016-07-12 16:06:34";"Thomas";"thomas@example.org";"2016-07-12 16:06:34";"deleted user";"thomas@example.org";"c6954cb75e3eeec5b827f64e97b6a4ba187c0d55";1;1;0;1;"test2.c";"foo";"Feature";1

--- a/util-data.R
+++ b/util-data.R
@@ -1647,7 +1647,8 @@ ProjectData = R6::R6Class("ProjectData",
                 verify.data.frame.columns(data, ISSUES.LIST.COLUMNS, ISSUES.LIST.DATA.TYPES)
             }
 
-            ## remove deleted and empty users
+            ## remove deleted user from the "author.name" column,
+            ## however, keep events where the user in the "event.info.1" column is empty or deleted
             data = remove.deleted.and.empty.user(data)
 
             private$issues.unfiltered = data

--- a/util-data.R
+++ b/util-data.R
@@ -21,7 +21,7 @@
 ## Copyright 2017 by Ferdinand Frank <frankfer@fim.uni-passau.de>
 ## Copyright 2018-2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2019-2020 by Anselm Fehnker <anselm@muenster.de>
-## Copyright 2020-2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
+## Copyright 2020-2021, 2023 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
 ## Copyright 2021 by Mirabdulla Yusifli <s8miyusi@stud.uni-saarland.de>
 ## Copyright 2022 by Jonathan Baumann <joba00002@stud.uni-saarland.de>
@@ -1070,6 +1070,9 @@ ProjectData = R6::R6Class("ProjectData",
                 verify.data.frame.columns(commit.data, COMMITS.LIST.COLUMNS, COMMITS.LIST.DATA.TYPES)
             }
 
+            ## remove commits that have no author or commiter
+            commit.data = remove.deleted.and.empty.user(commit.data, c("author.name", "committer.name"))
+
             ## store commit data
             private$commits.unfiltered = commit.data
 
@@ -1465,6 +1468,9 @@ ProjectData = R6::R6Class("ProjectData",
                 verify.data.frame.columns(mail.data, MAILS.LIST.COLUMNS, MAILS.LIST.DATA.TYPES)
             }
 
+            ## remove deleted and empty users
+            mail.data = remove.deleted.and.empty.user(mail.data)
+
             ## store mail data
             private$mails.unfiltered = mail.data
             private$mails = mail.data
@@ -1528,6 +1534,9 @@ ProjectData = R6::R6Class("ProjectData",
                 ## check that dataframe is of correct shape
                 verify.data.frame.columns(data, AUTHORS.LIST.COLUMNS, AUTHORS.LIST.DATA.TYPES)
             }
+
+            ## remove deleted and empty users
+            data = remove.deleted.and.empty.user(data)
 
             ## add gender data if wanted
             if (private$project.conf$get.value("gender")) {
@@ -1637,6 +1646,9 @@ ProjectData = R6::R6Class("ProjectData",
                 ## check that dataframe is of correct shape
                 verify.data.frame.columns(data, ISSUES.LIST.COLUMNS, ISSUES.LIST.DATA.TYPES)
             }
+
+            ## remove deleted and empty users
+            data = remove.deleted.and.empty.user(data)
 
             private$issues.unfiltered = data
             private$issues = create.empty.issues.list()

--- a/util-read.R
+++ b/util-read.R
@@ -47,14 +47,20 @@ requireNamespace("data.table") # for faster data.frame processing
 
 #' Remove the "deleted user" or the author with empty name "" from a data frame.
 #'
-#' @param data the data from which to remove the "deleted user" and author with empty name
+#' @param data the data from which to remove the "deleted user" and author with empty name.
 #' @param columns the columns in which to search for the "deleted user" and author with empty name.
-#'        The default value is \code{c("author.name")}.
+#'                [default: c("author.name")]
 #' 
 #' @return the data frame without the rows in which the author name is "deleted user" or ""
 remove.deleted.and.empty.user = function(data, columns = c("author.name")) {
+    if (!all(columns %in% names(data))) {
+        logging::logerror("The given columns are not present in the data.frame.")
+        stop("Stopped due to invalid column names.")    
+    }
+    
     ## create a copy of the original data frame
     df = data.frame(data)
+
     ## loop over the given columns and remove all rows in which the author name is "deleted user" or ""
     for (column in columns) {
         df = df[tolower(data[, column]) != "deleted user" & data[column] != "", ]

--- a/util-read.R
+++ b/util-read.R
@@ -396,7 +396,9 @@ read.issues = function(data.path, issues.sources = c("jira", "github")) {
         commit.added.events.before.creation = commit.added.events &
             !is.na(issue.data["creation.date"]) & (issue.data["date"] < issue.data["creation.date"])
         issue.data[commit.added.events.before.creation, "date"] = issue.data[commit.added.events.before.creation, "creation.date"]
-        issue.data = remove.deleted.and.empty.user(issue.data) # filter deleted user
+        ## filter deleted user from the "author.name" column,
+        ## however, keep events where the user in the "event.info.1" column is empty or deleted
+        issue.data = remove.deleted.and.empty.user(issue.data) 
         issue.data = issue.data[order(issue.data[["date"]], decreasing = FALSE), ] # sort!
     }
 

--- a/util-read.R
+++ b/util-read.R
@@ -19,7 +19,7 @@
 ## Copyright 2017-2018 by Thomas Bock <bockthom@fim.uni-passau.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2018-2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
-## Copyright 2020-2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
+## Copyright 2020-2021, 2023 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
 ## Copyright 2021 by Mirabdulla Yusifli <s8miyusi@stud.uni-saarland.de>
 ## Copyright 2022 by Jonathan Baumann <joba00002@stud.uni-saarland.de>
@@ -43,15 +43,23 @@ requireNamespace("sqldf") # for SQL-selections on data.frames
 requireNamespace("data.table") # for faster data.frame processing
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
-## Helper functions ---------------------------------------------------------------
+## Helper functions --------------------------------------------------------
 
 #' Remove the "deleted user" or the author with empty name "" from a data frame.
 #'
 #' @param data the data from which to remove the "deleted user" and author with empty name
-#'
+#' @param columns the columns in which to search for the "deleted user" and author with empty name.
+#'        The default value is \code{c("author.name")}.
+#' 
 #' @return the data frame without the rows in which the author name is "deleted user" or ""
-remove.deleted.and.empty.user = function(data) {
-    return(data[tolower(data[, "author.name"]) != "deleted user" & data["author.name"] != "", ])
+remove.deleted.and.empty.user = function(data, columns = c("author.name")) {
+    ## create a copy of the original data frame
+    df = data.frame(data)
+    ## loop over the given columns and remove all rows in which the author name is "deleted user" or ""
+    for (column in columns) {
+        df = df[tolower(data[, column]) != "deleted user" & data[column] != "", ]
+    }   
+    return(df)
 }
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
@@ -171,7 +179,7 @@ read.commits = function(data.path, artifact) {
                                           UNTRACKED.FILE.EMPTY.ARTIFACT.TYPE,
                                           commit.data[["artifact.type"]])
 
-    commit.data = remove.deleted.and.empty.user(commit.data) # filter deleted user
+    commit.data = remove.deleted.and.empty.user(commit.data, c("author.name", "committer.name")) # filter deleted user
 
     ## convert dates and sort by them
     commit.data[["date"]] = get.date.from.string(commit.data[["date"]])

--- a/util-read.R
+++ b/util-read.R
@@ -53,19 +53,16 @@ requireNamespace("data.table") # for faster data.frame processing
 #' 
 #' @return the data frame without the rows in which the author name is "deleted user" or ""
 remove.deleted.and.empty.user = function(data, columns = c("author.name")) {
-    if (!all(columns %in% names(data))) {
+    if (!all(columns %in% colnames(data))) {
         logging::logerror("The given columns are not present in the data.frame.")
         stop("Stopped due to invalid column names.")    
     }
-    
-    ## create a copy of the original data frame
-    df = data.frame(data)
 
     ## loop over the given columns and remove all rows in which the author name is "deleted user" or ""
     for (column in columns) {
-        df = df[tolower(data[, column]) != "deleted user" & data[column] != "", ]
+        data = data[tolower(data[, column]) != "deleted user" & data[column] != "", ]
     }   
-    return(df)
+    return(data)
 }
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /


### PR DESCRIPTION
The function in util-read.R now uses a vector containing the columns to check for deleted and ampty users. This is important for commits, because there, the column "committer.name" is also relevant.

Also use the function in the setter methods of util.data for mails, issues, commits, and authors right after input validation.

This addresses #213.
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

<!-- Add a description of the added/changed/fixed functionality in this pull request. -->

### Changelog

<!-- Put the updated/added parts of the changelog here. -->
