### PR TITLE
Tests and Fixes for utils-networks-misc.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,12 +8,16 @@
 
 - Add issue-based artifact-networks (PR #244, 98a93ee721a293410623aafe46890cfba9d81e72, 771bcc8d961d419b53a1e891e9dc536371f1143b)
 - Add a new `split.data.by.bins` function (not to be confused with a previously existing function that had the same name and was renamed in this context), which splits data based on given activity-based bins (PR #244, ece569ceaf557bb38cd0cfad437b69b30fe8a698, ed5feb214a123b605c9513262f187cfd72b9e1f4)
+- Add new `compare.sparse.matrices` function to compare two sparse matrices for equality for testing purposes (PR #248, 9784cdf12d1497ee122e2ae73b768b8c334210d4)
+- Add tests for file `util-networks.misc.R` (PR #248, f3202a6f96723d11c170346556d036cf087521c8, 030574b9d0f3435db4032d0e195a3d407fb7244b, 380b02234275127297fcd508772c69db21c216de, 8b803c50d60fc593e4e527a08fd4c2068d801a48, 7335c3dd4d0302b024a66d18701d9800ed3fe806, 6b600df04bec1fe70c272604f274ec5309840e65)
 
 ### Changed/Improved
 
 - Enhance testing data by adding `add_link` and `referenced_by` issue events which connect issues to form edges in issue-based artifact-networks (PR #244, 9f840c040d552e8639aa82c3dd537c189679b348, ea4fe8d3c84f948af6147cf0137e80181ebb7a1e)
 - Add input validation for the `bins` parameter in `split.data.time.based` and `split.data.by.bins` (PR #244, ed0a5302ea8c8934d7200b95be7ac1446305af07, 5e5ecbac44d07927b953ae9d4330a616f8224ba7)
 - Rename `split.data.by.bins` into `split.dataframe.by.bins` as this it what it does (PR #244, ed5feb214a123b605c9513262f187cfd72b9e1f4)
+- Enhance `get.author.names.from.network` and `get.author.names.from.data` to always have the same output format, not depending on the `global` flag (PR #248, d87d32564156f13c83ebe3361c2b68e5d0ac16ac, ddbfe68d3e628e82f34e09b36fffe886646986c5)
+- Changed `util-tensor.R` to correctly use `get.author.names.from.network` function
 
 ### Fixed
 
@@ -21,6 +25,10 @@
 - Fix an issue in activity-based splitting where elements close to the border of bins might be assigned to the wrong bin. The issue was caused by the usage of `split.data.time.based` inside `split.data.activity.based` to split data into the previously derived bins, when elements close to bin borders share the same timestamps. It is fixed by replacing `split.data.time.based` by `split.data.by.bins` (PR #244, ece569ceaf557bb38cd0cfad437b69b30fe8a698)
 - Remove the last range when using a sliding-window approach and the last range's elements are fully contained in the second last range (PR #244, 48ef4fa685adf6e5d85281e5b90a8ed8f6aeb197)
 - Rename vertex attribute `IssueEvent` to `Issue` in multi-networks, to be consistent with bipartite-networks (PR #244, 26d7b7e9fd6d33d1c0a8a08f19c5c2e30346a3d9)
+- Fix `get.expanded.adjacency` to work if provided author list does not contain all authors from network and add a warning when that happens because it causes some authors from the network to be lost in the resulting matrix (PR #248, ff59017e114b10812dcfb1704a19e01fc1586a13)
+- Fix `get.expanded.adjacency.matrices` to have correct names for the columns and rows (PR #248, e72eff864a1cb1a4aecd430e450d4a6a5044fdf2)
+- Fix `get.expanded.adjacency.cumulated` so that it works if `weighted` parameter is set to `FALSE` (PR #248, 2fb9a5d446653f6aee808cbfc87c2dafeb9a749a)
+- Fix `convert.adjacency.matrix.list.to.array` to throw an error if the function is called with wrong parameters (PR #248, ece2d38b4972745af3a83e06f32317a06465a345, 1a3e510df15f5fa4e920e9fce3e0e162c27cd6d1)
 
 
 ## 4.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,16 +8,18 @@
 
 - Add issue-based artifact-networks (PR #244, 98a93ee721a293410623aafe46890cfba9d81e72, 771bcc8d961d419b53a1e891e9dc536371f1143b)
 - Add a new `split.data.by.bins` function (not to be confused with a previously existing function that had the same name and was renamed in this context), which splits data based on given activity-based bins (PR #244, ece569ceaf557bb38cd0cfad437b69b30fe8a698, ed5feb214a123b605c9513262f187cfd72b9e1f4)
-- Add new `compare.sparse.matrices` function to compare two sparse matrices for equality for testing purposes (PR #248, 9784cdf12d1497ee122e2ae73b768b8c334210d4)
-- Add tests for file `util-networks.misc.R` (PR #248, f3202a6f96723d11c170346556d036cf087521c8, 030574b9d0f3435db4032d0e195a3d407fb7244b, 380b02234275127297fcd508772c69db21c216de, 8b803c50d60fc593e4e527a08fd4c2068d801a48, 7335c3dd4d0302b024a66d18701d9800ed3fe806, 6b600df04bec1fe70c272604f274ec5309840e65)
+- Add new `assert.sparse.matrices.equal` function to compare two sparse matrices for equality for testing purposes (PR #248, 9784cdf12d1497ee122e2ae73b768b8c334210d4, d9f1a8d90e00a634d7caeb5e7f8f262776496838)
+- Add tests for file `util-networks.misc.R` for issue #242 (PR #248, f3202a6f96723d11c170346556d036cf087521c8, 030574b9d0f3435db4032d0e195a3d407fb7244b, 380b02234275127297fcd508772c69db21c216de, 8b803c50d60fc593e4e527a08fd4c2068d801a48, 7335c3dd4d0302b024a66d18701d9800ed3fe806, 6b600df04bec1fe70c272604f274ec5309840e65)
 
 ### Changed/Improved
 
 - Enhance testing data by adding `add_link` and `referenced_by` issue events which connect issues to form edges in issue-based artifact-networks (PR #244, 9f840c040d552e8639aa82c3dd537c189679b348, ea4fe8d3c84f948af6147cf0137e80181ebb7a1e)
 - Add input validation for the `bins` parameter in `split.data.time.based` and `split.data.by.bins` (PR #244, ed0a5302ea8c8934d7200b95be7ac1446305af07, 5e5ecbac44d07927b953ae9d4330a616f8224ba7)
 - Rename `split.data.by.bins` into `split.dataframe.by.bins` as this it what it does (PR #244, ed5feb214a123b605c9513262f187cfd72b9e1f4)
-- Enhance `get.author.names.from.network` and `get.author.names.from.data` to always have the same output format, not depending on the `global` flag (PR #248, d87d32564156f13c83ebe3361c2b68e5d0ac16ac, ddbfe68d3e628e82f34e09b36fffe886646986c5)
-- Changed `util-tensor.R` to correctly use `get.author.names.from.network` function
+- Enhance `get.author.names.from.network` and `get.author.names.from.data` to always have the same output format. Now it doesn't depend on the `global` flag anymore (PR #248, d87d32564156f13c83ebe3361c2b68e5d0ac16ac, ddbfe68d3e628e82f34e09b36fffe886646986c5)
+- Change `util-tensor.R` to correctly use the new output format of `get.author.names.from.network` (PR #248, 72b663ebf7169c0da5c687fe215529f3be0c08c5)
+- Throw an error in `convert.adjacency.matrix.list.to.array` if the function is called with wrong parameters (PR #248, ece2d38b4972745af3a83e06f32317a06465a345, 1a3e510df15f5fa4e920e9fce3e0e162c27cd6d1)
+- Rename `compare.networks` to `assert.networks.equal` to better match the purpose of the function (PR #248, d9f1a8d90e00a634d7caeb5e7f8f262776496838)
 
 ### Fixed
 
@@ -25,10 +27,9 @@
 - Fix an issue in activity-based splitting where elements close to the border of bins might be assigned to the wrong bin. The issue was caused by the usage of `split.data.time.based` inside `split.data.activity.based` to split data into the previously derived bins, when elements close to bin borders share the same timestamps. It is fixed by replacing `split.data.time.based` by `split.data.by.bins` (PR #244, ece569ceaf557bb38cd0cfad437b69b30fe8a698)
 - Remove the last range when using a sliding-window approach and the last range's elements are fully contained in the second last range (PR #244, 48ef4fa685adf6e5d85281e5b90a8ed8f6aeb197)
 - Rename vertex attribute `IssueEvent` to `Issue` in multi-networks, to be consistent with bipartite-networks (PR #244, 26d7b7e9fd6d33d1c0a8a08f19c5c2e30346a3d9)
-- Fix `get.expanded.adjacency` to work if provided author list does not contain all authors from network and add a warning when that happens because it causes some authors from the network to be lost in the resulting matrix (PR #248, ff59017e114b10812dcfb1704a19e01fc1586a13)
+- Fix `get.expanded.adjacency` to work if the provided author list does not contain all authors from network and add a warning when that happens since it causes some authors from the network to be lost in the resulting matrix (PR #248, ff59017e114b10812dcfb1704a19e01fc1586a13)
 - Fix `get.expanded.adjacency.matrices` to have correct names for the columns and rows (PR #248, e72eff864a1cb1a4aecd430e450d4a6a5044fdf2)
 - Fix `get.expanded.adjacency.cumulated` so that it works if `weighted` parameter is set to `FALSE` (PR #248, 2fb9a5d446653f6aee808cbfc87c2dafeb9a749a)
-- Fix `convert.adjacency.matrix.list.to.array` to throw an error if the function is called with wrong parameters (PR #248, ece2d38b4972745af3a83e06f32317a06465a345, 1a3e510df15f5fa4e920e9fce3e0e162c27cd6d1)
 
 
 ## 4.3

--- a/tests/test-networks-artifact.R
+++ b/tests/test-networks-artifact.R
@@ -16,6 +16,7 @@
 ## Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2023 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
+## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -190,7 +191,7 @@ patrick::with_parameters_test_that("Network construction of an empty 'comments-o
     network.expected = igraph::graph.data.frame(edges, directed = test.directed, vertices = vertices)
 
     ## test
-    compare.networks(network.built, network.expected)
+    assert.networks.equal(network.built, network.expected)
 }, patrick::cases(
     "directed: FALSE" = list(test.directed = FALSE),
     "directed: TRUE" = list(test.directed = TRUE)

--- a/tests/test-networks-multi-relation.R
+++ b/tests/test-networks-multi-relation.R
@@ -20,6 +20,7 @@
 ## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
 ## Copyright 2022 by Jonathan Baumann <joba00002@stud.uni-saarland.de>
 ## Copyright 2023 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
+## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -312,7 +313,7 @@ test_that("Construction of the multi network for the feature artifact with autho
     network.expected = igraph::graph.data.frame(edges, vertices = vertices,
                                                 directed = net.conf$get.value("author.directed"))
 
-    compare.networks(network.expected, network.built)
+    assert.networks.equal(network.expected, network.built)
 })
 
 test_that("Construction of the multi-artifact bipartite network with artifact relations 'cochange' and 'issue'", {
@@ -407,7 +408,7 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
 
     net.expected = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
 
-    compare.networks(net.expected, net.combined)
+    assert.networks.equal(net.expected, net.combined)
 
 })
 
@@ -494,7 +495,7 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
 
     net.expected = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
 
-    compare.networks(net.expected, net.combined)
+    assert.networks.equal(net.expected, net.combined)
 
 })
 
@@ -596,7 +597,7 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
 
     net.expected = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
 
-    compare.networks(net.expected, net.combined)
+    assert.networks.equal(net.expected, net.combined)
 
 })
 
@@ -716,6 +717,6 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
 
     net.expected = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
 
-    compare.networks(net.expected, net.combined)
+    assert.networks.equal(net.expected, net.combined)
 
 })

--- a/tests/test-networks-multi.R
+++ b/tests/test-networks-multi.R
@@ -16,6 +16,7 @@
 ## Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 ## Copyright 2022 by Jonathan Baumann <joba00002@stud.uni-saarland.de>
 ## Copyright 2023 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
+## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -92,6 +93,6 @@ test_that("Construction of the multi network for the feature artifact with autho
 
               network.expected = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
 
-              compare.networks(network.expected, network.built)
+              assert.networks.equal(network.expected, network.built)
           })
 

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -1,0 +1,160 @@
+## This file is part of coronet, which is free software: you
+## can redistribute it and/or modify it under the terms of the GNU General
+## Public License as published by  the Free Software Foundation, version 2.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License along
+## with this program; if not, write to the Free Software Foundation, Inc.,
+## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+##
+## Copyright 2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
+## Copyright 2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
+## Copyright 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2022 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2019 by Christian Hechtl <hechtl@fim.uni-passau.de>
+## Copyright 2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
+## All Rights Reserved.
+
+
+context("Tests for the file 'util-networks-misc.R'")
+
+##
+## Context
+##
+
+CF.DATA = file.path(".", "codeface-data")
+CF.SELECTION.PROCESS = "testing"
+CASESTUDY = "test"
+ARTIFACT = "feature"
+
+## use only when debugging this file independently
+if (!dir.exists(CF.DATA)) CF.DATA = file.path(".", "tests", "codeface-data")
+
+test_that("getting all authors of a list of networks, list length 0", {
+
+    ## Act
+    result = get.author.names.from.networks(networks = list(), globally = TRUE)
+    
+    ## Assert
+    expected = list(c())
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of networks, list length 1", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    network = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+
+    ## Act
+    result = get.author.names.from.networks(networks = list(network))
+
+    ## Assert
+    expected = list(c("Dieter", "Heinz", "Klaus"))
+    
+    expect_equal(expected, result)
+
+})
+
+test_that("getting all authors of a list of networks, list length 1, not global", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    network = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+
+    ## Act
+    result = get.author.names.from.networks(networks = list(network), globally = FALSE)
+
+    ## Assert
+    expected = list(c("Dieter", "Heinz", "Klaus"))
+    
+    expect_equal(expected, result)
+
+})
+
+test_that("getting all authors of a list of networks, list length 2", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    first.network = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+
+    second.vertices = data.frame(
+        name = c("Detlef", "Dieter"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    second.edges = data.frame(
+        from = "Detlef",
+        to = "Dieter"
+        )
+    second.network = igraph::graph.data.frame(second.edges, directed = FALSE, vertices = second.vertices)
+    ## Act
+    result = get.author.names.from.networks(networks = list(first.network, second.network))
+
+    ## Assert
+    expected = list(c("Detlef", "Dieter", "Heinz", "Klaus"))
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of networks, list length 2, not global", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    first.network = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+
+    second.vertices = data.frame(
+        name = c("Detlef", "Dieter"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    second.edges = data.frame(
+        from = "Detlef",
+        to = "Dieter"
+        )
+    second.network = igraph::graph.data.frame(second.edges, directed = FALSE, vertices = second.vertices)
+    ## Act
+    result = get.author.names.from.networks(networks = list(first.network, second.network), globally = FALSE)
+
+    ## Assert
+    expected = list(c("Dieter", "Heinz", "Klaus"), c("Detlef", "Dieter"))
+    
+    expect_equal(expected, result)
+})

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -158,3 +158,141 @@ test_that("getting all authors of a list of networks, list length 2, not global"
     
     expect_equal(expected, result)
 })
+
+test_that("getting all authors of a list of data ranges, list length 0", {
+
+    ## Act
+    result = get.author.names.from.data(data.ranges = list())
+    
+    ## Assert
+    expected = list(c())
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of data ranges, list length 1", {
+
+    ## Arrange
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data.base = ProjectData$new(project.conf = proj.conf)
+    range.data = proj.data.base$get.data.cut.to.same.date("mails")
+
+    ## Act
+    result = get.author.names.from.data(data.ranges = list(range.data))
+    
+    ## Assert
+    expected = list(c("Björn", "Fritz fritz@example.org","georg", "Hans", 
+                    "Karl", "Olaf", "Thomas", "udo"))
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of data ranges, list length 1, not global", {
+
+    ## Arrange
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data.base = ProjectData$new(project.conf = proj.conf)
+    range.data = proj.data.base$get.data.cut.to.same.date("mails")
+
+    ## Act
+    result = get.author.names.from.data(data.ranges = list(range.data), globally = FALSE)
+    
+    ## Assert
+    expected = list(c("Björn", "Fritz fritz@example.org","georg", "Hans", 
+                    "Karl", "Olaf", "Thomas", "udo"))
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of data ranges, list length 2", {
+
+    ## Arrange
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data.base = ProjectData$new(project.conf = proj.conf)
+    range.data.one = proj.data.base$get.data.cut.to.same.date("mails")
+    range.data.two = proj.data.base$get.data.cut.to.same.date("issues")
+
+    ## Act
+    result = get.author.names.from.data(data.ranges = list(range.data.one, range.data.two))
+    
+    ## Assert
+    expected = list(c("Björn", "Fritz fritz@example.org","georg", "Hans", 
+                    "Karl", "Max", "Olaf", "Thomas", "udo"))
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of data ranges, list length 2, not global", {
+
+    ## Arrange
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data.base = ProjectData$new(project.conf = proj.conf)
+    range.data.one = proj.data.base$get.data.cut.to.same.date("mails")
+    range.data.two = proj.data.base$get.data.cut.to.same.date("issues")
+
+    ## Act
+    result = get.author.names.from.data(data.ranges = list(range.data.one, range.data.two), globally = FALSE)
+    
+    ## Assert
+    expected = list(c("Björn", "Fritz fritz@example.org","georg", "Hans", "Karl", "Olaf",
+                        "Thomas", "udo"), c("Björn", "Karl", "Max", "Olaf", "Thomas"))
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of data ranges by data source 'mails', list length 2, not global", {
+
+    ## Arrange
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data.base = ProjectData$new(project.conf = proj.conf)
+    range.data.one = proj.data.base$get.data.cut.to.same.date("mails")
+    range.data.two = proj.data.base$get.data.cut.to.same.date("issues")
+
+    ## Act
+    result = get.author.names.from.data(data.ranges = list(range.data.one, range.data.two), 
+                                                            data.sources = "mails", globally = FALSE)
+    
+    ## Assert
+    
+    expected = list(c("Björn", "Fritz fritz@example.org","georg", "Hans", "Olaf",
+                        "Thomas", "udo"), c("Björn", "Olaf", "Thomas"))
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of data ranges by data source 'issues', list length 2, not global", {
+
+    ## Arrange
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data.base = ProjectData$new(project.conf = proj.conf)
+    range.data.one = proj.data.base$get.data.cut.to.same.date("mails")
+    range.data.two = proj.data.base$get.data.cut.to.same.date("issues")
+
+    ## Act
+    result = get.author.names.from.data(data.ranges = list(range.data.one, range.data.two), 
+                                                            data.sources = "issues", globally = FALSE)
+    
+    ## Assert
+    expected = list(c("Björn", "Karl", "Olaf", "Thomas"), c("Björn","Karl", "Max", "Olaf", "Thomas"))
+    
+    expect_equal(expected, result)
+})
+
+test_that("getting all authors of a list of data ranges by data source 'commits', list length 2, not global", {
+
+    ## Arrange
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.data.base = ProjectData$new(project.conf = proj.conf)
+    range.data.one = proj.data.base$get.data.cut.to.same.date("mails")
+    range.data.two = proj.data.base$get.data.cut.to.same.date("issues")
+
+    ## Act
+    result = get.author.names.from.data(data.ranges = list(range.data.one, range.data.two), 
+                                                            data.sources = "commits", globally = FALSE)
+    
+    ## Assert
+    
+    expected = list(c("Björn", "Olaf"), c("Björn", "Olaf", "Thomas"))
+    
+    expect_equal(expected, result)
+})

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -631,3 +631,109 @@ test_that("getting a sparse adjacency matrix per network, two networks", {
     ## Assert
     expect_equal(list(matrix.out.one, matrix.out.two), result)
 })
+
+test_that("getting cumulative sums of adjacency matrices generated from networks, two networks", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Heinz", "Dieter", "Dieter"),
+        to = c("Dieter", "Klaus", "Heinz")
+        )
+    network.in.one = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.one = sort(c("Heinz", "Dieter", "Klaus"))
+
+    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in.one), length(authors.in.one)),
+                                            repr = "T")
+    rownames(matrix.out.one) = authors.in.one
+    colnames(matrix.out.one) = authors.in.one
+
+    matrix.out.one["Heinz", "Dieter"] = 1
+    matrix.out.one["Klaus", "Dieter"] = 1
+    matrix.out.one["Dieter", "Heinz"] = 1
+    matrix.out.one["Dieter", "Klaus"] = 1
+
+    edges = data.frame(
+        from = c("Klaus"),
+        to = c("Dieter")
+        )
+    network.in.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.two = sort(c("Heinz", "Dieter", "Klaus"))
+
+    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in.two), length(authors.in.two)),
+                                            repr = "T")
+    rownames(matrix.out.two) = authors.in.two
+    colnames(matrix.out.two) = authors.in.two
+
+    matrix.out.two["Heinz", "Dieter"] = 1
+    matrix.out.two["Klaus", "Dieter"] = 1
+    matrix.out.two["Dieter", "Heinz"] = 1
+    matrix.out.two["Dieter", "Klaus"] = 1
+    
+    ## Act
+    result = get.expanded.adjacency.cumulated(networks = list(network.in.one, network.in.two))
+    
+    ## Assert
+    compare.sparse.matrices(matrix.out.one, result[[1]])
+    compare.sparse.matrices(matrix.out.two, result[[2]])
+})
+
+test_that("getting cumulative sums of adjacency matrices generated from networks, two networks, weighted", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Heinz", "Dieter", "Dieter"),
+        to = c("Dieter", "Klaus", "Heinz"),
+        weight = c(1, 2, 1)
+        )
+    network.in.one = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.one = sort(c("Heinz", "Dieter", "Klaus"))
+
+    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in.one), length(authors.in.one)),
+                                            repr = "T")
+    rownames(matrix.out.one) = authors.in.one
+    colnames(matrix.out.one) = authors.in.one
+
+    matrix.out.one["Heinz", "Dieter"] = 2
+    matrix.out.one["Klaus", "Dieter"] = 2
+    matrix.out.one["Dieter", "Heinz"] = 2
+    matrix.out.one["Dieter", "Klaus"] = 2
+
+    edges = data.frame(
+        from = c("Klaus"),
+        to = c("Dieter"),
+        weight = c(1)
+        )
+    network.in.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.two = sort(c("Heinz", "Dieter", "Klaus"))
+
+    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in.two), length(authors.in.two)),
+                                            repr = "T")
+    rownames(matrix.out.two) = authors.in.two
+    colnames(matrix.out.two) = authors.in.two
+    
+    matrix.out.two["Heinz", "Dieter"] = 2
+    matrix.out.two["Klaus", "Dieter"] = 3
+    matrix.out.two["Dieter", "Heinz"] = 2
+    matrix.out.two["Dieter", "Klaus"] = 3
+    
+    ## Act
+    result = get.expanded.adjacency.cumulated(networks = list(network.in.one, network.in.two), weighted = TRUE)
+    
+    ## Assert
+    compare.sparse.matrices(matrix.out.one, result[[1]])
+    compare.sparse.matrices(matrix.out.two, result[[2]])
+})

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -11,12 +11,7 @@
 ## with this program; if not, write to the Free Software Foundation, Inc.,
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
-## Copyright 2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
-## Copyright 2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
-## Copyright 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
-## Copyright 2022 by Thomas Bock <bockthom@cs.uni-saarland.de>
-## Copyright 2019 by Christian Hechtl <hechtl@fim.uni-passau.de>
-## Copyright 2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
+## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -675,8 +675,8 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
     result = get.expanded.adjacency.cumulated(networks = list(network.in.one, network.in.two))
     
     ## Assert
-    compare.sparse.matrices(matrix.out.one, result[[1]])
-    compare.sparse.matrices(matrix.out.two, result[[2]])
+    assert.sparse.matrices.equal(matrix.out.one, result[[1]])
+    assert.sparse.matrices.equal(matrix.out.two, result[[2]])
 })
 
 test_that("getting cumulative sums of adjacency matrices generated from networks, two networks, weighted", {
@@ -729,8 +729,8 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
     result = get.expanded.adjacency.cumulated(networks = list(network.in.one, network.in.two), weighted = TRUE)
     
     ## Assert
-    compare.sparse.matrices(matrix.out.one, result[[1]])
-    compare.sparse.matrices(matrix.out.two, result[[2]])
+    assert.sparse.matrices.equal(matrix.out.one, result[[1]])
+    assert.sparse.matrices.equal(matrix.out.two, result[[2]])
 })
 
 test_that("getting cumulative sums of adjacency matrices generated from networks, 

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -530,3 +530,104 @@ test_that("getting a sparse adjacency matrix for a network, three edges, more au
     ## Assert
     expect_equal(matrix.out, result)
 })
+
+test_that("getting a sparse adjacency matrix per network, zero networks", {
+    ## Act
+    result = get.expanded.adjacency.matrices(networks = list())
+
+    ## Assert
+    expect_equal(list(), result)
+})
+
+test_that("getting a sparse adjacency matrix per network, one network", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Heinz", "Dieter", "Dieter"),
+        to = c("Dieter", "Klaus", "Heinz")
+        )
+    network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in = sort(c("Heinz", "Dieter", "Klaus"))
+
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in), length(authors.in)),
+                                            repr = "T")
+    rownames(matrix.out) = authors.in
+    colnames(matrix.out) = authors.in
+
+    # order these statements so that the second arguments are ordered alphabetically
+    # or use the helper function as used below
+    matrix.out["Heinz", "Dieter"] = 1
+    matrix.out["Klaus", "Dieter"] = 1
+    matrix.out["Dieter", "Heinz"] = 1
+    matrix.out["Dieter", "Klaus"] = 1
+    
+    ## Act
+    result = get.expanded.adjacency.matrices(networks = list(network.in))
+
+    ## Assert
+    expect_equal(list(matrix.out), result)
+})
+
+test_that("getting a sparse adjacency matrix per network, two networks", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Heinz", "Dieter", "Dieter"),
+        to = c("Dieter", "Klaus", "Heinz")
+        )
+    network.in.one = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.one = sort(c("Heinz", "Dieter", "Klaus"))
+
+    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in.one), length(authors.in.one)),
+                                            repr = "T")
+    rownames(matrix.out.one) = authors.in.one
+    colnames(matrix.out.one) = authors.in.one
+
+    # order these statements so that the second arguments are ordered alphabetically
+    # or use the helper function as used below
+    matrix.out.one["Heinz", "Dieter"] = 1
+    matrix.out.one["Klaus", "Dieter"] = 1
+    matrix.out.one["Dieter", "Heinz"] = 1
+    matrix.out.one["Dieter", "Klaus"] = 1
+
+    vertices = data.frame(
+        name = c("Klaus", "Tobias"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Klaus"),
+        to = c("Tobias")
+        )
+    network.in.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.two = sort(c("Klaus", "Tobias"))
+
+    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in.two), length(authors.in.two)),
+                                            repr = "T")
+    rownames(matrix.out.two) = authors.in.two
+    colnames(matrix.out.two) = authors.in.two
+
+    # order these statements so that the second arguments are ordered alphabetically 
+    # or use the helper function as used below
+    matrix.out.two["Tobias", "Klaus"] = 1
+    matrix.out.two["Klaus", "Tobias"] = 1
+    
+    ## Act
+    result = get.expanded.adjacency.matrices(networks = list(network.in.one, network.in.two))
+    
+    ## Assert
+    expect_equal(list(matrix.out.one, matrix.out.two), result)
+})

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -296,3 +296,237 @@ test_that("getting all authors of a list of data ranges by data source 'commits'
     
     expect_equal(expected, result)
 })
+
+test_that("getting a sparse adjacency matrix for a network, single edge, matching author list", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in = c("Heinz", "Dieter", "Klaus")
+
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in), length(authors.in)),
+                                            repr = "T")
+    rownames(matrix.out) = authors.in
+    colnames(matrix.out) = authors.in
+    
+    matrix.out["Heinz", "Dieter"] = 1
+    matrix.out["Dieter", "Heinz"] = 1
+    
+    ## Act
+    result = get.expanded.adjacency(network =network.in, authors = authors.in)
+    
+    ## Assert
+    
+    expect_equal(matrix.out, result)
+
+})
+
+test_that("getting a sparse adjacency matrix for a network, single edge, fewer authors than network", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in = c("Dieter", "Heinz")
+
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in), length(authors.in)),
+                                            repr = "T")
+    rownames(matrix.out) = authors.in
+    colnames(matrix.out) = authors.in
+
+    matrix.out["Heinz", "Dieter"] = 1
+    matrix.out["Dieter", "Heinz"] = 1
+    
+    ## Act
+    result = get.expanded.adjacency(network =network.in, authors = authors.in)
+    
+    ## Assert
+    
+    expect_equal(matrix.out, result)
+
+})
+
+test_that("getting a sparse adjacency matrix for a network, single edge, more authors than network", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in = c("Gerhardt", "Bob", "Dieter", "Heinz", "Klaus")
+
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in), length(authors.in)),
+                                            repr = "T")
+    rownames(matrix.out) = authors.in
+    colnames(matrix.out) = authors.in
+
+    matrix.out["Heinz", "Dieter"] = 1
+    matrix.out["Dieter", "Heinz"] = 1
+    
+    ## Act
+    result = get.expanded.adjacency(network =network.in, authors = authors.in)
+    
+    ## Assert
+    
+    expect_equal(matrix.out, result)
+
+})
+
+test_that("getting a sparse adjacency matrix for a network, single edge, no matching author list", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in = c("Gerhardt", "Bob", "Dieter", "Heinz")
+
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in), length(authors.in)),
+                                            repr = "T")
+    rownames(matrix.out) = authors.in
+    colnames(matrix.out) = authors.in
+
+    matrix.out["Heinz", "Dieter"] = 1
+    matrix.out["Dieter", "Heinz"] = 1
+    
+    ## Act
+    result = get.expanded.adjacency(network =network.in, authors = authors.in)
+    
+    ## Assert
+    
+    expect_equal(matrix.out, result)
+
+})
+
+test_that("getting a sparse adjacency matrix for a network, single edge, no overlap in author list", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = "Heinz",
+        to = "Dieter"
+        )
+    network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in = c("Gerhardt", "Bob")
+
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in), length(authors.in)),
+                                            repr = "T")
+    rownames(matrix.out) = authors.in
+    colnames(matrix.out) = authors.in
+    
+    ## Act
+    result = get.expanded.adjacency(network =network.in, authors = authors.in)
+    
+    ## Assert
+    
+    expect_equal(matrix.out, result)
+
+})
+
+test_that("getting a sparse adjacency matrix for a network, two edges, more authors than network", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Heinz", "Dieter"),
+        to = c("Dieter", "Klaus")
+        )
+    network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in = c("Klaus", "Gerhardt", "Bob", "Dieter", "Heinz")
+
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in), length(authors.in)),
+                                            repr = "T")
+    rownames(matrix.out) = authors.in
+    colnames(matrix.out) = authors.in
+
+    # order these statements so that the second arguments are ordered alphabetically
+    # or use the helper function as used below
+    matrix.out["Heinz", "Dieter"] = 1
+    matrix.out["Klaus", "Dieter"] = 1
+    matrix.out["Dieter", "Heinz"] = 1
+    matrix.out["Dieter", "Klaus"] = 1
+    
+    ## Act
+    result = get.expanded.adjacency(network =network.in, authors = authors.in)
+
+    ## Assert
+    expect_equal(matrix.out, result)
+
+})
+
+test_that("getting a sparse adjacency matrix for a network, three edges, more authors than network, weighted", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Heinz", "Dieter", "Dieter"),
+        to = c("Dieter", "Klaus", "Heinz"),
+        weight = c(1, 3, 4)
+        )
+    network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in = c("Klaus", "Gerhardt", "Bob", "Dieter", "Heinz")
+
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
+                                            dims = c(length(authors.in), length(authors.in)),
+                                            repr = "T")
+    rownames(matrix.out) = authors.in
+    colnames(matrix.out) = authors.in
+
+    # order these statements so that the second arguments are ordered alphabetically
+    # or use the helper function as used below
+    matrix.out["Heinz", "Dieter"] = 5
+    matrix.out["Klaus", "Dieter"] = 3
+    matrix.out["Dieter", "Heinz"] = 5
+    matrix.out["Dieter", "Klaus"] = 3
+    
+    ## Act
+    result = get.expanded.adjacency(network =network.in, authors = authors.in, weighted = TRUE)
+    
+    ## Assert
+    expect_equal(matrix.out, result)
+})

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -737,3 +737,94 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
     compare.sparse.matrices(matrix.out.one, result[[1]])
     compare.sparse.matrices(matrix.out.two, result[[2]])
 })
+
+test_that("getting cumulative sums of adjacency matrices generated from networks, 
+                    two networks, then convert to array", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Heinz", "Dieter", "Dieter"),
+        to = c("Dieter", "Klaus", "Heinz")
+        )
+    network.in.one = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.one = sort(c("Heinz", "Dieter", "Klaus"))
+
+    edges = data.frame(
+        from = c("Klaus"),
+        to = c("Dieter")
+        )
+    network.in.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+
+    expected.array = array(data = 0, dim = c(3, 3, 2))
+    rownames(expected.array) = authors.in.one
+    colnames(expected.array) = authors.in.one
+
+    expected.array[1, 2, 1] = 1
+    expected.array[1, 3, 1] = 1
+    expected.array[2, 1, 1] = 1
+    expected.array[3, 1, 1] = 1
+
+    expected.array[1, 2, 2] = 1
+    expected.array[1, 3, 2] = 1
+    expected.array[2, 1, 2] = 1
+    expected.array[3, 1, 2] = 1
+
+    ## Act
+    result.adjacency = get.expanded.adjacency.cumulated(networks = list(network.in.one, network.in.two))
+    result.array = convert.adjacency.matrix.list.to.array(result.adjacency)
+    
+    ## Assert
+    expect_equal(expected.array, result.array)
+})
+
+test_that("getting cumulative sums of adjacency matrices generated from networks, 
+                    two networks, weighted, then convert to array", {
+
+    ## Arrange
+    vertices = data.frame(
+        name = c("Heinz", "Dieter", "Klaus"),
+        kind = TYPE.AUTHOR,
+        type = TYPE.AUTHOR
+        )
+    edges = data.frame(
+        from = c("Heinz", "Dieter", "Dieter"),
+        to = c("Dieter", "Klaus", "Heinz"),
+        weight = c(1, 2, 1)
+        )
+    network.in.one = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.one = sort(c("Heinz", "Dieter", "Klaus"))
+
+    edges = data.frame(
+        from = c("Klaus"),
+        to = c("Dieter"),
+        weight = c(1)
+        )
+    network.in.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    authors.in.two = sort(c("Heinz", "Dieter", "Klaus"))
+
+    expected.array = array(data = 0, dim = c(3, 3, 2))
+    rownames(expected.array) = authors.in.one
+    colnames(expected.array) = authors.in.one
+
+    expected.array[1, 2, 1] = 2
+    expected.array[1, 3, 1] = 2
+    expected.array[2, 1, 1] = 2
+    expected.array[3, 1, 1] = 2
+
+    expected.array[1, 2, 2] = 2
+    expected.array[1, 3, 2] = 3
+    expected.array[2, 1, 2] = 2
+    expected.array[3, 1, 2] = 3
+
+    ## Act
+    result.adjacency = get.expanded.adjacency.cumulated(networks = list(network.in.one, network.in.two), weighted = TRUE)
+    result.array = convert.adjacency.matrix.list.to.array(result.adjacency)
+    
+    ## Assert
+    expect_equal(expected.array, result.array)
+})

--- a/tests/test-util-networks-misc.R
+++ b/tests/test-util-networks-misc.R
@@ -112,6 +112,7 @@ test_that("getting all authors of a list of networks, list length 2", {
         to = "Dieter"
         )
     second.network = igraph::graph.data.frame(second.edges, directed = FALSE, vertices = second.vertices)
+
     ## Act
     result = get.author.names.from.networks(networks = list(first.network, second.network))
 
@@ -145,6 +146,7 @@ test_that("getting all authors of a list of networks, list length 2, not global"
         to = "Dieter"
         )
     second.network = igraph::graph.data.frame(second.edges, directed = FALSE, vertices = second.vertices)
+    
     ## Act
     result = get.author.names.from.networks(networks = list(first.network, second.network), globally = FALSE)
 
@@ -177,7 +179,7 @@ test_that("getting all authors of a list of data ranges, list length 1", {
     
     ## Assert
     expected = list(c("Björn", "Fritz fritz@example.org","georg", "Hans", 
-                    "Karl", "Olaf", "Thomas", "udo"))
+                      "Karl", "Olaf", "Thomas", "udo"))
     
     expect_equal(expected, result)
 })
@@ -194,7 +196,7 @@ test_that("getting all authors of a list of data ranges, list length 1, not glob
     
     ## Assert
     expected = list(c("Björn", "Fritz fritz@example.org","georg", "Hans", 
-                    "Karl", "Olaf", "Thomas", "udo"))
+                      "Karl", "Olaf", "Thomas", "udo"))
     
     expect_equal(expected, result)
 })
@@ -265,7 +267,7 @@ test_that("getting all authors of a list of data ranges by data source 'issues',
 
     ## Act
     result = get.author.names.from.data(data.ranges = list(range.data.one, range.data.two), 
-                                                            data.sources = "issues", globally = FALSE)
+                                                           data.sources = "issues", globally = FALSE)
     
     ## Assert
     expected = list(c("Björn", "Karl", "Olaf", "Thomas"), c("Björn","Karl", "Max", "Olaf", "Thomas"))
@@ -283,7 +285,7 @@ test_that("getting all authors of a list of data ranges by data source 'commits'
 
     ## Act
     result = get.author.names.from.data(data.ranges = list(range.data.one, range.data.two), 
-                                                            data.sources = "commits", globally = FALSE)
+                                                           data.sources = "commits", globally = FALSE)
     
     ## Assert
     
@@ -307,9 +309,8 @@ test_that("getting a sparse adjacency matrix for a network, single edge, matchin
     network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in = c("Heinz", "Dieter", "Klaus")
 
-    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in), length(authors.in)),
-                                            repr = "T")
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in),
+                                      length(authors.in)), repr = "T")
     rownames(matrix.out) = authors.in
     colnames(matrix.out) = authors.in
     
@@ -340,9 +341,8 @@ test_that("getting a sparse adjacency matrix for a network, single edge, fewer a
     network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in = c("Dieter", "Heinz")
 
-    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in), length(authors.in)),
-                                            repr = "T")
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in),
+                                      length(authors.in)), repr = "T")
     rownames(matrix.out) = authors.in
     colnames(matrix.out) = authors.in
 
@@ -350,7 +350,7 @@ test_that("getting a sparse adjacency matrix for a network, single edge, fewer a
     matrix.out["Dieter", "Heinz"] = 1
     
     ## Act
-    result = get.expanded.adjacency(network =network.in, authors = authors.in)
+    result = get.expanded.adjacency(network = network.in, authors = authors.in)
     
     ## Assert
     
@@ -373,9 +373,8 @@ test_that("getting a sparse adjacency matrix for a network, single edge, more au
     network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in = c("Gerhardt", "Bob", "Dieter", "Heinz", "Klaus")
 
-    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in), length(authors.in)),
-                                            repr = "T")
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in),
+                                      length(authors.in)), repr = "T")
     rownames(matrix.out) = authors.in
     colnames(matrix.out) = authors.in
 
@@ -406,9 +405,8 @@ test_that("getting a sparse adjacency matrix for a network, single edge, no matc
     network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in = c("Gerhardt", "Bob", "Dieter", "Heinz")
 
-    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in), length(authors.in)),
-                                            repr = "T")
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in),
+                                      length(authors.in)), repr = "T")
     rownames(matrix.out) = authors.in
     colnames(matrix.out) = authors.in
 
@@ -439,9 +437,8 @@ test_that("getting a sparse adjacency matrix for a network, single edge, no over
     network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in = c("Gerhardt", "Bob")
 
-    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in), length(authors.in)),
-                                            repr = "T")
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in),
+                                      length(authors.in)), repr = "T")
     rownames(matrix.out) = authors.in
     colnames(matrix.out) = authors.in
     
@@ -469,9 +466,8 @@ test_that("getting a sparse adjacency matrix for a network, two edges, more auth
     network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in = c("Klaus", "Gerhardt", "Bob", "Dieter", "Heinz")
 
-    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in), length(authors.in)),
-                                            repr = "T")
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in),
+                                      length(authors.in)), repr = "T")
     rownames(matrix.out) = authors.in
     colnames(matrix.out) = authors.in
 
@@ -506,9 +502,8 @@ test_that("getting a sparse adjacency matrix for a network, three edges, more au
     network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in = c("Klaus", "Gerhardt", "Bob", "Dieter", "Heinz")
 
-    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in), length(authors.in)),
-                                            repr = "T")
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in),
+                                      length(authors.in)), repr = "T")
     rownames(matrix.out) = authors.in
     colnames(matrix.out) = authors.in
 
@@ -549,9 +544,8 @@ test_that("getting a sparse adjacency matrix per network, one network", {
     network.in = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in = sort(c("Heinz", "Dieter", "Klaus"))
 
-    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in), length(authors.in)),
-                                            repr = "T")
+    matrix.out = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in),
+                                      length(authors.in)), repr = "T")
     rownames(matrix.out) = authors.in
     colnames(matrix.out) = authors.in
 
@@ -584,9 +578,8 @@ test_that("getting a sparse adjacency matrix per network, two networks", {
     network.in.one = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in.one = sort(c("Heinz", "Dieter", "Klaus"))
 
-    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in.one), length(authors.in.one)),
-                                            repr = "T")
+    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in.one),
+                                          length(authors.in.one)), repr = "T")
     rownames(matrix.out.one) = authors.in.one
     colnames(matrix.out.one) = authors.in.one
 
@@ -609,9 +602,8 @@ test_that("getting a sparse adjacency matrix per network, two networks", {
     network.in.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in.two = sort(c("Klaus", "Tobias"))
 
-    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in.two), length(authors.in.two)),
-                                            repr = "T")
+    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in.two),
+                                          length(authors.in.two)), repr = "T")
     rownames(matrix.out.two) = authors.in.two
     colnames(matrix.out.two) = authors.in.two
 
@@ -642,9 +634,8 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
     network.in.one = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in.one = sort(c("Heinz", "Dieter", "Klaus"))
 
-    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in.one), length(authors.in.one)),
-                                            repr = "T")
+    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in.one),
+                                          length(authors.in.one)), repr = "T")
     rownames(matrix.out.one) = authors.in.one
     colnames(matrix.out.one) = authors.in.one
 
@@ -660,9 +651,8 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
     network.in.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in.two = sort(c("Heinz", "Dieter", "Klaus"))
 
-    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in.two), length(authors.in.two)),
-                                            repr = "T")
+    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in.two),
+                                          length(authors.in.two)), repr = "T")
     rownames(matrix.out.two) = authors.in.two
     colnames(matrix.out.two) = authors.in.two
 
@@ -695,9 +685,8 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
     network.in.one = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in.one = sort(c("Heinz", "Dieter", "Klaus"))
 
-    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in.one), length(authors.in.one)),
-                                            repr = "T")
+    matrix.out.one = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in.one),
+                                          length(authors.in.one)), repr = "T")
     rownames(matrix.out.one) = authors.in.one
     colnames(matrix.out.one) = authors.in.one
 
@@ -714,9 +703,8 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
     network.in.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
     authors.in.two = sort(c("Heinz", "Dieter", "Klaus"))
 
-    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, 
-                                            dims = c(length(authors.in.two), length(authors.in.two)),
-                                            repr = "T")
+    matrix.out.two = Matrix::sparseMatrix(i = c(), j = c(), x = 0, dims = c(length(authors.in.two),
+                                          length(authors.in.two)), repr = "T")
     rownames(matrix.out.two) = authors.in.two
     colnames(matrix.out.two) = authors.in.two
     
@@ -734,7 +722,7 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
 })
 
 test_that("getting cumulative sums of adjacency matrices generated from networks, 
-                    two networks, then convert to array", {
+          two networks, then convert to array", {
 
     ## Arrange
     vertices = data.frame(
@@ -778,7 +766,7 @@ test_that("getting cumulative sums of adjacency matrices generated from networks
 })
 
 test_that("getting cumulative sums of adjacency matrices generated from networks, 
-                    two networks, weighted, then convert to array", {
+          two networks, weighted, then convert to array", {
 
     ## Arrange
     vertices = data.frame(

--- a/tests/testing-utils.R
+++ b/tests/testing-utils.R
@@ -12,6 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2022 by Jonathan Baumann <joba00002@stud.uni-saarland.de>
+## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /

--- a/tests/testing-utils.R
+++ b/tests/testing-utils.R
@@ -133,3 +133,20 @@ compare.networks = function(network.expected, network.actual) {
     expect_identical(expected.edges, actual.edges, info = "network edges")
     expect_identical(expected.vertices, actual.vertices, info = "network vertices")
 }
+
+#' Compare two sparse matrices
+#' 
+#' @param matrix.expected the expected matrix
+#' @param matrix.actual the actual matrix
+compare.sparse.matrices = function(matrix.expected, matrix.actual) {
+    # check if colnames and rownames are equal
+    expect_equal(colnames(matrix.expected), colnames(matrix.actual))
+    expect_equal(rownames(matrix.expected), rownames(matrix.actual))
+    # check if matrices have the same size
+    expected.size = length(matrix.expected)
+    expect_equal(expected.size, length(matrix.actual))
+    # check if contents are the same
+    for(i in 1 : expected.size) {
+        expect_equal(matrix.expected[i], matrix.actual[i])
+    }
+}

--- a/tests/testing-utils.R
+++ b/tests/testing-utils.R
@@ -147,7 +147,7 @@ assert.sparse.matrices.equal = function(matrix.expected, matrix.actual) {
     expected.size = length(matrix.expected)
     expect_equal(expected.size, length(matrix.actual))
     # check if contents are the same
-    for(i in 1 : expected.size) {
+    for (i in seq_len(expected.size)) {
         expect_equal(matrix.expected[i], matrix.actual[i])
     }
 }

--- a/tests/testing-utils.R
+++ b/tests/testing-utils.R
@@ -118,11 +118,11 @@ remove.row.names.from.inner.list.of.dfs = function(list.of.lists.of.dfs) {
     return(lapply(list.of.lists.of.dfs, remove.row.names.from.data))
 }
 
-#' Compare edges and vertices of two networks
+#' Assert that two networks are equal. Used for testing purposes.
 #'
 #' @param network.expected the expected network
 #' @param network.actual the actual network
-compare.networks = function(network.expected, network.actual) {
+assert.networks.equal = function(network.expected, network.actual) {
     ## TODO  as soon as the bug in igraph is fixed switch to the expect_true function below
     # expect_true(igraph::identical_graphs(network.expected, network.actual))
     expected.edges = igraph::as_data_frame(network.expected, what = "edges")
@@ -135,11 +135,11 @@ compare.networks = function(network.expected, network.actual) {
     expect_identical(expected.vertices, actual.vertices, info = "network vertices")
 }
 
-#' Compare two sparse matrices
+#' Assert that two sparse matrices are equal. Used for testing purposes.
 #' 
 #' @param matrix.expected the expected matrix
 #' @param matrix.actual the actual matrix
-compare.sparse.matrices = function(matrix.expected, matrix.actual) {
+assert.sparse.matrices.equal = function(matrix.expected, matrix.actual) {
     # check if colnames and rownames are equal
     expect_equal(colnames(matrix.expected), colnames(matrix.actual))
     expect_equal(rownames(matrix.expected), rownames(matrix.actual))

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -18,6 +18,7 @@
 ## Copyright 2017 by Angelika Schmid <schmidang@fim.uni-passau.de>
 ## Copyright 2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2019-2020 by Anselm Fehnker <anselm@muenster.de>
+## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -229,16 +230,30 @@ get.expanded.adjacency.cumulated = function(networks, weighted = FALSE) {
 }
 
 #' Converts a list of adjacency matrices to an array.
+#' Expects matrices of equal dimension with equal colomn- and rownames.
 #'
 #' @param adjacency.list the list of adjacency matrices
 #'
 #' @return the converted array
 convert.adjacency.matrix.list.to.array = function(adjacency.list){
 
+    ## Check if all matrices have equal colomn- and rownames
+    rownames = rownames(adjacency.list[[1]])
+    colnames = colnames(adjacency.list[[1]])
+    
+    if (length(adjacency.list) > 1) {
+        for(i in 2 : length(adjacency.list)) {
+            if (!identical(rownames, rownames(adjacency.list[[i]])) || !identical(colnames, colnames(adjacency.list[[i]]))) {
+                warning.string = sprintf("The matrix at position %d has a different col or rownames from the first!", i)
+                warning(warning.string)
+            }
+        }
+    }
+
     ## create a 3-dimensional array representing the adjacency matrices (SIENA data format) as result
     array = array(data = 0, dim = c(nrow(adjacency.list[[1]]), nrow(adjacency.list[[1]]), length(adjacency.list)))
-    rownames(array) = rownames(adjacency.list[[1]])
-    colnames(array) = colnames(adjacency.list[[1]])
+    rownames(array) = rownames
+    colnames(array) = colnames
 
     ## copy the activity values from the adjacency matrices in the list to the corresponding array slices
     for (i in seq_along(adjacency.list)) {

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -135,13 +135,22 @@ get.expanded.adjacency = function(network, authors, weighted = FALSE) {
             ## get the weighted adjacency matrix for the current network
             matrix.data = igraph::get.adjacency(network, attr = "weight")
         } else {
-            ## get the unweighted adjacency matrix for the current network
+            ## get the unweighted sparse adjacency matrix for the current network
             matrix.data = igraph::get.adjacency(network)
         }
-
-        ## order the adjacency matrix
+        
+        network.authors.num = nrow(matrix.data)
+        ## order the adjacency matrix and filter out authors that were not in authors list
         if (nrow(matrix.data) > 1) { # for a 1x1 matrix ordering does not work
-            matrix.data = matrix.data[order(rownames(matrix.data)), order(colnames(matrix.data))]
+            matrix.data = matrix.data[order((rownames(matrix.data)[rownames(matrix.data) %in% authors])), 
+                            order((rownames(matrix.data)[rownames(matrix.data) %in% authors]))]
+        }
+
+        if(network.authors.num > nrow(matrix.data)) { 
+            # write a warning with the number of authors from the network that we ignore
+            warning.string = sprintf("The network had %d authors that will not be displayed in the matrix!",
+                                        network.authors.num - nrow(matrix.data))
+            warning(warning.string)
         }
 
         ## save the activity data per author

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -208,16 +208,17 @@ get.expanded.adjacency.cumulated = function(networks, weighted = FALSE) {
             matrices.cumulated[[m]] = matrices.cumulated[[m - 1]] + matrices[[m]]
             rownames(matrices.cumulated[[m]]) = rownames(matrices.cumulated[[m - 1]])
             colnames(matrices.cumulated[[m]]) = colnames(matrices.cumulated[[m - 1]])
-
+            
             if (!weighted) {
 
                 ## search for a non-zero entry and set them to an arbitray number (e.g., 42)
                 ## to force that all non-zero entries are correctly set to 1 afterwards
-                not.zero.idxs = which(matrices.cumulated[[m]] >= 1, arr.ind = TRUE)
-                if (nrow(not.zero.idxs) > 0) {
-                    first.not.zero.idx = not.zero.idxs[1, ]
-                    names(first.not.zero.idx) = c("row", "col")
-                    matrices.cumulated[[m]][first.not.zero.idx[["row"]], first.not.zero.idx[["col"]]] = 42
+                if(length(matrices.cumulated[[m]]@i) > 0) {
+                
+                    row = matrices.cumulated[[m]]@i[[1]] + 1
+                    col = matrices.cumulated[[m]]@j[[1]] + 1
+
+                    matrices.cumulated[[m]][row][col] = 42
                     matrices.cumulated[[m]]@x = rep(1, length(matrices.cumulated[[m]]@i))
                 }
             }

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -177,9 +177,11 @@ get.expanded.adjacency = function(network, authors, weighted = FALSE) {
 #' @return the list of adjacency matrices
 get.expanded.adjacency.matrices = function(networks, weighted = FALSE){
 
-    authors = get.author.names.from.networks(networks)
-
-    adjacency.matrices = parallel::mclapply(networks, get.expanded.adjacency, authors, weighted)
+    adjacency.matrices = parallel::mclapply(networks, function(network) {
+        active.authors = igraph::V(network)$name
+        active.authors = sort(active.authors)
+        return (get.expanded.adjacency(network = network, authors = active.authors, weighted = weighted))
+    })
 
     return(adjacency.matrices)
 }

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -237,6 +237,10 @@ get.expanded.adjacency.cumulated = function(networks, weighted = FALSE) {
 #' @return the converted array
 convert.adjacency.matrix.list.to.array = function(adjacency.list){
 
+    if (length(adjacency.list) < 1) {
+        logging::logerror("The method convert.adjacency.matrix.list.to.array received an empty list!")
+        stop("The method convert.adjacency.matrix.list.to.array received an empty list!")
+    }
     ## Check if all matrices have equal colomn- and rownames
     rownames = rownames(adjacency.list[[1]])
     colnames = colnames(adjacency.list[[1]])
@@ -244,12 +248,13 @@ convert.adjacency.matrix.list.to.array = function(adjacency.list){
     if (length(adjacency.list) > 1) {
         for(i in 2 : length(adjacency.list)) {
             if (!identical(rownames, rownames(adjacency.list[[i]])) || !identical(colnames, colnames(adjacency.list[[i]]))) {
-                warning.string = sprintf("The matrix at position %d has a different col or rownames from the first!", i)
-                warning(warning.string)
+                error.string = sprintf("The matrix at position %d has a different col or rownames from the first!", i)
+                logging::logerror(error.string)
+                stop(error.string)
             }
         }
     }
-
+    
     ## create a 3-dimensional array representing the adjacency matrices (SIENA data format) as result
     array = array(data = 0, dim = c(nrow(adjacency.list[[1]]), nrow(adjacency.list[[1]]), length(adjacency.list)))
     rownames(array) = rownames

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -36,26 +36,28 @@ requireNamespace("Matrix") # for sparse matrices
 #' @param networks the list of networks from which the author names are wanted
 #' @param globally decides if all author names are in one list or in separate lists for each network [default: TRUE]
 #'
-#' @return the list of author names
+#' @return the list of author names as a list of vectors
 get.author.names.from.networks = function(networks, globally = TRUE) {
-
+    
     ## for each network, get a list of authors that are in this network
     active.authors.list = lapply(networks, function(network) {
         active.authors = igraph::V(network)$name
+        active.authors = sort(active.authors)
         return(active.authors)
     })
 
     if (globally) {
         ## flatten the list of lists to one list of authors
         active.authors = unlist(active.authors.list, recursive = FALSE)
-
+        
         ## remove distracting named list members
         names(active.authors) = NULL
 
         ## remove duplicates and order alphabetically ascending
         active.authors = active.authors[!duplicated(active.authors)]
         active.authors = sort(active.authors)
-        return(active.authors)
+        ## return as a list
+        return(list(active.authors))
     } else {
         return(active.authors.list)
     }

--- a/util-networks-misc.R
+++ b/util-networks-misc.R
@@ -71,22 +71,22 @@ get.author.names.from.networks = function(networks, globally = TRUE) {
 #'                    or any combination of them [default: c("commits", "mails", "issues")]
 #' @param globally decides if all author names are in one list or in separate for each network [default: TRUE]
 #'
-#' @return the list of author names
+#' @return the list of author names as a list of vectors
 get.author.names.from.data = function(data.ranges, data.sources = c("commits", "mails", "issues"), globally = TRUE) {
 
     data.sources = match.arg.or.default(data.sources, several.ok = TRUE)
 
     ## for each range, get the authors who have been active on at least one data source in this range
     active.authors.list = lapply(data.ranges, function(range.data) {
-
+        
         active.authors = range.data$get.authors.by.data.source(data.sources)
-
-        active.authors.names = active.authors[["author.name"]]
+    
+        active.authors.names = sort(active.authors[["author.name"]])
 
         return(active.authors.names)
 
     })
-
+    
     if (globally) {
         ## flatten the list of lists to one list of authors
         active.authors = unlist(active.authors.list, recursive = FALSE)
@@ -97,7 +97,8 @@ get.author.names.from.data = function(data.ranges, data.sources = c("commits", "
         ## remove duplicates and order alphabetically ascending
         active.authors = active.authors[!duplicated(active.authors)]
         active.authors = sort(active.authors)
-        return(active.authors)
+        ## return as a list
+        return(list(active.authors))
     } else {
         return(active.authors.list)
     }

--- a/util-tensor.R
+++ b/util-tensor.R
@@ -56,8 +56,7 @@ FourthOrderTensor = R6::R6Class("FourthOrderTensor",
         build.tensor.from.networks = function(networks, weighted = FALSE) {
 
             ## get adjacency matrices from networks
-            adjacency.matrices = parallel::mclapply(networks, get.expanded.adjacency, private$authors, weighted)
-
+            adjacency.matrices = get.expanded.adjacency.matrices(networks, weighted)
             ## create an array with the size of the fourth-order tensor that only contains zeros
             array = array(0, dim = private$dim)
 
@@ -93,7 +92,7 @@ FourthOrderTensor = R6::R6Class("FourthOrderTensor",
         initialize = function(networks, weighted = FALSE) {
 
             private$relations = names(networks)
-            private$authors = get.author.names.from.networks(networks)
+            private$authors = get.author.names.from.networks(networks)[[1]]
             private$dim = c(length(private$authors), length(private$relations), length(private$authors), length(private$relations))
             private$tensor = private$build.tensor.from.networks(networks, weighted)
 

--- a/util-tensor.R
+++ b/util-tensor.R
@@ -12,6 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2019-2020 by Anselm Fehnker <anselm@muenster.de>
+## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

This Pull request fixes #242 

### Changelog

### Added

- Add new `assert.sparse.matrices.equal` function to compare two sparse matrices for equality for testing purposes (PR #248, 9784cdf12d1497ee122e2ae73b768b8c334210d4, d9f1a8d90e00a634d7caeb5e7f8f262776496838)
- Add tests for file `util-networks.misc.R` for issue #242 (PR #248, f3202a6f96723d11c170346556d036cf087521c8, 030574b9d0f3435db4032d0e195a3d407fb7244b, 380b02234275127297fcd508772c69db21c216de, 8b803c50d60fc593e4e527a08fd4c2068d801a48, 7335c3dd4d0302b024a66d18701d9800ed3fe806, 6b600df04bec1fe70c272604f274ec5309840e65)


### Changed/Improved

- Enhance `get.author.names.from.network` and `get.author.names.from.data` to always have the same output format. Now it doesn't depend on the `global` flag anymore (PR #248, d87d32564156f13c83ebe3361c2b68e5d0ac16ac, ddbfe68d3e628e82f34e09b36fffe886646986c5)
- Change `util-tensor.R` to correctly use the new output format of `get.author.names.from.network` (PR #248, 72b663ebf7169c0da5c687fe215529f3be0c08c5)
- Fix `convert.adjacency.matrix.list.to.array` to throw an error if the function is called with wrong parameters (PR #248, ece2d38b4972745af3a83e06f32317a06465a345, 1a3e510df15f5fa4e920e9fce3e0e162c27cd6d1)
- Rename `compare.networks` to `assert.networks.equal` to better match the purpose of the function (PR #248, d9f1a8d90e00a634d7caeb5e7f8f262776496838)


### Fixed

- Fix `get.expanded.adjacency` to work if the provided author list does not contain all authors from network and add a warning when that happens since it causes some authors from the network to be lost in the resulting matrix (PR #248, ff59017e114b10812dcfb1704a19e01fc1586a13)
- Fix `get.expanded.adjacency.matrices` to have correct names for the columns and rows (PR #248, e72eff864a1cb1a4aecd430e450d4a6a5044fdf2)
- Fix `get.expanded.adjacency.cumulated` so that it works if `weighted` parameter is set to `FALSE` (PR #248, 2fb9a5d446653f6aee808cbfc87c2dafeb9a749a)