### PR TITLE
Enable simplification of multi-relation edges & make multi-network construction work with igraph version 2.0.1.1

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,6 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2023 by Maximilian Löffler <s8maloef@cs.uni-saarland.de>
+## Copyright 2024 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 name: Build Status
@@ -29,17 +30,17 @@ permissions:
 jobs:
   build:
     name: Build
-    
+
     # change to 'runs-on: self-hosted' to run on self-hosted runners (https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job)
     runs-on: ubuntu-latest
-    
+
     strategy:
       fail-fast: false
       matrix:
-        r-version: ['3.6', '4.0', '4.1', '4.2', 'latest']
+        r-version: ['3.6', '4.0', '4.1', '4.2', '4.3', 'latest']
 
     steps:
-      - name: Checkout Repo 
+      - name: Checkout Repo
         uses: actions/checkout@v3
 
       - name: Update system
@@ -56,7 +57,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
-      
+
       - name: Install dependencies
         run: Rscript install.R
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,10 +6,11 @@
 
 ### Added
 
-- Add issue-based artifact-networks (PR #244, 98a93ee721a293410623aafe46890cfba9d81e72, 771bcc8d961d419b53a1e891e9dc536371f1143b)
+- Add issue-based artifact-networks (PR #244, 98a93ee721a293410623aafe46890cfba9d81e72, 771bcc8d961d419b53a1e891e9dc536371f1143b, 368e79264adf5a5358c04518c94ad2e1c13e212b)
 - Add a new `split.data.by.bins` function (not to be confused with a previously existing function that had the same name and was renamed in this context), which splits data based on given activity-based bins (PR #244, ece569ceaf557bb38cd0cfad437b69b30fe8a698, ed5feb214a123b605c9513262f187cfd72b9e1f4)
 - Add new `assert.sparse.matrices.equal` function to compare two sparse matrices for equality for testing purposes (PR #248, 9784cdf12d1497ee122e2ae73b768b8c334210d4, d9f1a8d90e00a634d7caeb5e7f8f262776496838)
 - Add tests for file `util-networks.misc.R` for issue #242 (PR #248, f3202a6f96723d11c170346556d036cf087521c8, 030574b9d0f3435db4032d0e195a3d407fb7244b, 380b02234275127297fcd508772c69db21c216de, 8b803c50d60fc593e4e527a08fd4c2068d801a48, 7335c3dd4d0302b024a66d18701d9800ed3fe806, 6b600df04bec1fe70c272604f274ec5309840e65)
+- Add the possibility to simplify edges of multiple-relation networks into a single edge at all instead of a single edge per relation (PR #250, 2105ea89b5227e7c9fa78fea9de1977f2d9e8faa)
 
 ### Changed/Improved
 
@@ -20,6 +21,7 @@
 - Change `util-tensor.R` to correctly use the new output format of `get.author.names.from.network` (PR #248, 72b663ebf7169c0da5c687fe215529f3be0c08c5)
 - Throw an error in `convert.adjacency.matrix.list.to.array` if the function is called with wrong parameters (PR #248, ece2d38b4972745af3a83e06f32317a06465a345, 1a3e510df15f5fa4e920e9fce3e0e162c27cd6d1)
 - Rename `compare.networks` to `assert.networks.equal` to better match the purpose of the function (PR #248, d9f1a8d90e00a634d7caeb5e7f8f262776496838)
+- Explicitly add R version 4.3 to the CI test pipeline (9f346d5bc3cfc553f01e5e80f0bbe51e1dc2b53e)
 
 ### Fixed
 
@@ -30,6 +32,8 @@
 - Fix `get.expanded.adjacency` to work if the provided author list does not contain all authors from network and add a warning when that happens since it causes some authors from the network to be lost in the resulting matrix (PR #248, ff59017e114b10812dcfb1704a19e01fc1586a13)
 - Fix `get.expanded.adjacency.matrices` to have correct names for the columns and rows (PR #248, e72eff864a1cb1a4aecd430e450d4a6a5044fdf2)
 - Fix `get.expanded.adjacency.cumulated` so that it works if `weighted` parameter is set to `FALSE` (PR #248, 2fb9a5d446653f6aee808cbfc87c2dafeb9a749a)
+- Fix broken error loggingin `metrics.smallworldness` (03e06881f06abf30d44b69d7988873f20b95232d)
+- Fix multi-network construction to work with igraph version 2.0.1.1, which does not allow to add an empty list of vertices (PR #250, 5547896faa279f6adaae4b2b77c7ab9623ddf256)
 
 
 ## 4.3

--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ Updates to the parameters can be done by calling `NetworkConf$update.variables(.
     * possible values: [*`"cochange"`*, `"callgraph"`, `"mail"`, `"issue"`]
 - `artifact.directed`
     * The directedness of edges in an artifact network
-    * **Note**: This parameter does not take effect for now, as the `cochange` relation is always undirected, while the `callgraph` relation is always directed. For the other relations (`mail` and `issue`), we currently do not have data available to exhibit edge information.
+    * **Note**: This parameter does only affect the `issue` relation, as the `cochange` relation is always undirected, while the `callgraph` relation is always directed. For the `mail`, we currently do not have data available to exhibit edge information.
   * [`TRUE`, *`FALSE`*]
 - `edge.attributes`
     * The list of edge-attribute names and information

--- a/README.md
+++ b/README.md
@@ -654,6 +654,10 @@ Updates to the parameters can be done by calling `NetworkConf$update.variables(.
 - `simplify`
     * Perform edge contraction to retrieve a simplified network
     * [`TRUE`, *`FALSE`*]
+- `simplify.multiple.relations`
+    * Whether the simplified network should contract edges of multiple relations into a single edge or not (if not, there will be one edge for each relation, resulting in possibly more than one edge between a pair of vertices)
+    * **Note** This parameter does not take effect if ``simplify = FALSE``!
+    * [`TRUE`, *`FALSE`*]
 - `skip.threshold`
     * The upper bound for total amount of edges to build for a subset of the data, i.e., not building any edges for the subset exceeding the limit
     * any positive integer

--- a/util-conf.R
+++ b/util-conf.R
@@ -18,7 +18,7 @@
 ## Copyright 2020-2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2017-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
-## Copyright 2021, 2023 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2021, 2023-2024 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 ## Copyright 2018-2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
@@ -863,6 +863,12 @@ NetworkConf = R6::R6Class("NetworkConf", inherit = Conf,
                 allowed = c(TRUE, FALSE),
                 allowed.number = 1
             ),
+            simplify.multiple.relations = list(
+               default = FALSE,
+               type = "logical",
+               allowed = c(TRUE, FALSE),
+               allowed.number = 1
+           ),
             skip.threshold = list(
                 default = Inf,
                 type = "numeric",

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -12,7 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2015, 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
-## Copyright 2021, 2023 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2021, 2023-2024 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 ## Copyright 2017-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017-2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
@@ -167,7 +167,7 @@ metrics.smallworldness = function(network) {
     if (!is.simple(network)) {
         ## if this is not the case, raise an error and stop the execution
         error.message = "The input network has too many edges. Try again with a simplified network."
-        logging::error(error.message)
+        logging::logerror(error.message)
         stop(error.message)
     }
 

--- a/util-networks.R
+++ b/util-networks.R
@@ -958,8 +958,10 @@ NetworkBuilder = R6::R6Class("NetworkBuilder",
             ## to be consistent with bipartite networks
             artifacts.to.add.kind[artifacts.to.add.kind == "IssueEvent"] = "Issue"
 
-            artifacts.net = artifacts.net + igraph::vertices(artifacts.to.add, type = TYPE.ARTIFACT,
-                                                             kind = artifacts.to.add.kind)
+            if (length(artifacts.to.add) > 0) {
+                artifacts.net = artifacts.net + igraph::vertices(artifacts.to.add, type = TYPE.ARTIFACT,
+                                                                 kind = artifacts.to.add.kind)
+            }
 
             ## check directedness and adapt artifact network if needed
             if (igraph::is.directed(authors.net) && !igraph::is.directed(artifacts.net)) {


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [X] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [X] I have updated the copyright headers of the files I have modified.
- [X] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [X] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [X] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [X] The pull request is opened against the branch `dev`.

### Description
This PR addresses multiple issues:

- It fixes #246 (i.e., fixes a broken logerror statement)
- If adjusts multi-network construction such that it works with the recently released igraph version 2.0.1.1, in which it is not possible any more to add an empty list of vertices. A simple check for an empty list fixes this problem.
- It updates the README regarding the effectiveness of network conf parameter "artifact.directed", which now is effective as of PR #244.
- It enables multi-relation edges to be simplified. That is, the simplify methods get an additional parameter and also the network configuration gets an additional parameter to decided whether edges between a pair of vertices should be contracted to a single edge when the edges are of different relations. The default behavior stays as before, that is, edges of different relations are not contracted during simplification. However, notice that the implementation of this feature is not complete, as also the edge attribute handling needs to be adjusted accordingly, and also proper tests are missing. I leave this open to a future PR -  I have summarized the steps that are still missing in issue #251.

### Changelog

#### Added
- Add the possibility to simplify edges of multiple-relation networks into a single edge at all instead of a single edge per relation (PR #250, 2105ea89b5227e7c9fa78fea9de1977f2d9e8faa)

#### Changed/Improved
- Explicitly add R version 4.3 to the CI test pipeline (9f346d5bc3cfc553f01e5e80f0bbe51e1dc2b53e)

#### Fixed
- Fix broken error logging in `metrics.smallworldness` (03e06881f06abf30d44b69d7988873f20b95232d)
- Fix multi-network construction to work with igraph version 2.0.1.1, which does not allow to add an empty list of vertices (PR #250, 5547896faa279f6adaae4b2b77c7ab9623ddf256)
