### PR TITLE
Fix a bug in 'extract.timestamps' when dealing with an empty data source

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 ### Fixed
 
 - Fix the creation of edgelists for issue-based artifact-networks by correctly iterating over the issue data (PR #264, 321d85043112971c04998249c14a0677a32c9004)
+- Fix a bug in `extract.timestamps` that occurs when the first `data.source` contains empty data and that leads to a return value of type numeric which should be POSIXct (PR #270, 10696e4cf4ae92371917ed8ccaec2b0183da145c, 646c01a42ad8decfbc9040030e790e51cb65cffd)
 
 ## 4.4
 

--- a/tests/test-data-cut.R
+++ b/tests/test-data-cut.R
@@ -18,6 +18,7 @@
 ## Copyright 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
 ## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
+## Copyright 2024 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -80,5 +81,65 @@ test_that("Cut commit and mail data to same date range.", {
 
     expect_identical(commit.data, commit.data.expected, info = "Cut Raw commit data.")
     expect_identical(mail.data, mail.data.expected, info = "Cut mail data.")
+
+})
+
+test_that("Cut data to same date range with one empty data source.", {
+
+    ## configurations
+
+    proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+
+    ## in order to properly test whether the data types of timestamps originating from empty data are correct,
+    ## ensure that the first provided data source contains empty data. This is important as R usually uses the
+    ## first entry of a data frame to determine the data type of it. However, the data type of the project timestamps
+    ## should be properly set regardless of the empty data.
+    proj.conf$update.value("issues.locked", TRUE)
+    data.sources = c("issues", "mails", "commits")
+
+    ## construct objects
+
+    x.data = ProjectData$new(proj.conf)
+    x.data$set.issues(NULL)
+
+    commit.data.expected = data.frame(commit.id = sprintf("<commit-%s>", c(32712, 32713)),
+                                      date = get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45")),
+                                      author.name = c("Björn", "Olaf"),
+                                      author.email = c("bjoern@example.org", "olaf@example.org"),
+                                      committer.date = get.date.from.string(c("2016-07-12 15:58:59", "2016-07-20 10:00:44")),
+                                      committer.name = c("Björn", "Björn"),
+                                      committer.email = c("bjoern@example.org", "bjoern@example.org"),
+                                      hash = c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338"),
+                                      changed.files = as.integer(c(1, 1)),
+                                      added.lines = as.integer(c(1, 1)),
+                                      deleted.lines = as.integer(c(1, 0)),
+                                      diff.size = as.integer(c(2, 1)),
+                                      file = c("test.c", "test.c"),
+                                      artifact = c("A", "A"),
+                                      artifact.type = c("Feature", "Feature"),
+                                      artifact.diff.size = as.integer(c(1, 1)))
+
+    mail.data.expected = data.frame(author.name = c("Thomas", "Olaf"),
+                                    author.email = c("thomas@example.org", "olaf@example.org"),
+                                    message.id = c("<65a1sf31sagd684dfv31@mail.gmail.com>", "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>"),
+                                    date = get.date.from.string(c("2016-07-12 16:04:40", "2016-07-12 16:05:37")),
+                                    date.offset = as.integer(c(100, 200)),
+                                    subject = c("Re: Fw: busybox 2 tab", "Re: Fw: busybox 10"),
+                                    thread = sprintf("<thread-%s>", c("13#9", "13#9")),
+                                    artifact.type = c("Mail", "Mail"))
+
+    issue.data.expected = create.empty.issues.list()
+
+    commit.data = x.data$get.data.cut.to.same.date(data.sources = data.sources)$get.commits.unfiltered()
+    rownames(commit.data) = 1:nrow(commit.data)
+
+    mail.data = x.data$get.data.cut.to.same.date(data.sources = data.sources)$get.mails()
+    rownames(mail.data) = 1:nrow(mail.data)
+
+    issue.data = x.data$get.data.cut.to.same.date(data.sources = data.sources)$get.issues()
+
+    expect_identical(commit.data, commit.data.expected, info = "Cut Raw commit data.")
+    expect_identical(mail.data, mail.data.expected, info = "Cut mail data.")
+    expect_identical(issue.data, issue.data.expected, info = "Cut issue data (empty).")
 
 })

--- a/util-data.R
+++ b/util-data.R
@@ -25,7 +25,7 @@
 ## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
 ## Copyright 2021 by Mirabdulla Yusifli <s8miyusi@stud.uni-saarland.de>
 ## Copyright 2022 by Jonathan Baumann <joba00002@stud.uni-saarland.de>
-## Copyright 2022-2023 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
+## Copyright 2022-2024 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
 ## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
@@ -113,7 +113,7 @@ DATASOURCE.TO.ARTIFACT.COLUMN = list(
 
 
 ## the maximum time difference between subsequent mails of a patchstack
-PATCHSTACK.MAIL.DECAY.THRESHOLD = "30 seconds"
+PATCHSTACK.MAIL.DECAY.THRESHOLD = lubridate::as.duration("30 seconds")
 
 ## configuration parameters that do not reset the environment when changed
 CONF.PARAMETERS.NO.RESET.ENVIRONMENT = c("commit.messages",
@@ -283,8 +283,7 @@ ProjectData = R6::R6Class("ProjectData",
                 ## of 'PATCHSTACK.MAIL.DECAY.THRESHOLD'
                 while (i < nrow(thread) && running) {
                     if (thread[1, "author.name"] == thread[i + 1, "author.name"] &&
-                        thread[i + 1, "date"] - thread[i, "date"] <=
-                        lubridate::as.duration(PATCHSTACK.MAIL.DECAY.THRESHOLD)) {
+                        thread[i + 1, "date"] - thread[i, "date"] <= PATCHSTACK.MAIL.DECAY.THRESHOLD) {
                         i = i + 1
                     } else {
                         running = FALSE

--- a/util-data.R
+++ b/util-data.R
@@ -797,8 +797,8 @@ ProjectData = R6::R6Class("ProjectData",
             }
             ## NAs otherwise
             else {
-                source.date.min = NA
-                source.date.max = NA
+                source.date.min = as.POSIXct(NA)
+                source.date.max = as.POSIXct(NA)
             }
 
             ## remove old line if existing


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

<!-- Add a description of the added/changed/fixed functionality in this pull request. -->

Include a fix by @bockthom for issue #269 and a new unit test for the previously faulty behavior.

### Changelog

<!-- Put the updated/added parts of the changelog here. -->

Fixed:
* Fix a bug in `extract.timestamps` that occurs when the first `data.source` is empty and leads to a return value of type `numeric` which should be `POSIXct`.
