### PR TITLE
Change default representation of edge attributes from vectors to lists & other miscellaneous adjustments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 ## unversioned
 
+### Announcement
+
+- Coronet is not compatible anymore with igraph versions below 2.1.0. This is due to the simultaneous deprecation of `subgraph.edges` and the introduction of the replacement for it, `subgraph_from_edges`, in igraph version 2.1.0.
+
 ### Added
 
 - Add commit-interaction data and add functions `read.commit.interactions` for reading, as well as `get.commit.interactions`, `set.commit.interactions` and utility functions for working with commit-interaction data (PR #252, d82857fbebd1111bb16588a4223bb24a8dcd07de, b4fd2a29c9b5fd561b1106c6febb54a32b0085ab, fd0aa05f824b93545ae8e05833b95b3bd9809286, bca35760eb0aac86c04923f2d534b2d8cece204e, PR #263, 849123a8b7d898fbb1343745ecffc1f6000c9367, 3fb7437b68950303916b62984fa449732c70353e, 170bc66eb779d7cf2ab504db7c3f4ec483103838) as well as tests for these features (PR #252, eeba7e29932bc973513c963fb9e716e9230d570f, 8bb39f4df39b49dfaff8f19feb6db5e5fbd81fac, 54b6f655248720436af116fe72521f9cb0348429, 7a5497aaf9114017d1b3b9b68b6cccd7ca8ac114, 7b8585f87675795822c07230192d6454de31dcc7, ef725407bf8818c8fff96ea6f343338b7162cbe0,)
@@ -18,8 +22,9 @@
 
 ### Changed/Improved
 
+- **Breaking Change**: Change the default representation of edge attributes from vectors to lists. This change is necessary for the interplay of coronet networks with certain igraph functionality since igraph version 2.1. (PR #274, 1c35d1fa2548deb297dbfa5e2b07fce31962c5b7, eda30b838369ec46376812298a3ea8159eec5789, 44c7b72e3234cb332bb2713fb408c124e67255d9, 7303eabef6a78198575fe5bdfc02813fde3d3974)
 - Change the default value for the `issues.from.source` configuration parameter. Instead of reading JIRA and GitHub issues together, which was the previous default, the new default value causes only GitHub issue data to be read. To restore the previous default behavior and read data from both issue sources, this now needs to be manually configured when needed. (PR #264, 5ff83c364f6bfc1e6ff95e9c5f1087e031c48a5d, 8c8080cb9caf115f19d9f145ad6e6c108b131a67, 8bcbc81db521877908d2e5c2989082ed672f2a3b)
-- Replace deprecated `igraph` functions by their preferred alternatives (PR #264, PR #268, 0df9d5bf6bafbb5d440f4c47db4ec901cf11f037, 7ac840d287a862eff61b1a84e194a4cba399f9e5)
+- Replace deprecated `igraph` functions by their preferred alternatives (PR #264, PR #268, PR #274, 0df9d5bf6bafbb5d440f4c47db4ec901cf11f037, 7ac840d287a862eff61b1a84e194a4cba399f9e5, e3617b8c6b21fb4242c1d392124813501069ca84, 4b0d5221dd56bb3c9ddf196f67719d4f503d9b61)
 - Deprecate support for R version 3.6 (PR #264, c8e6f45111e487fadbe7f0a13c7595eb23f3af6e, fb3f5474259d4a88f4ff545691cca9d1ccde90e3)
 - Explicitly add R version 4.4 to the CI test pipeline (c8e6f45111e487fadbe7f0a13c7595eb23f3af6e)
 - Refactor function `construct.edge.list.from.key.value.list` to be more readable (PR #263, 05c3bc09cb1d396fd59c34a88030cdca58fd04dd)
@@ -28,6 +33,9 @@
 
 - Fix the creation of edgelists for issue-based artifact-networks by correctly iterating over the issue data (PR #264, 321d85043112971c04998249c14a0677a32c9004)
 - Fix a bug in `extract.timestamps` that occurs when the first `data.source` contains empty data and that leads to a return value of type numeric which should be POSIXct (PR #270, 10696e4cf4ae92371917ed8ccaec2b0183da145c, 646c01a42ad8decfbc9040030e790e51cb65cffd)
+- Fix `read.commit.interactions` by explicitly considering non-existent commit interaction data (PR #274, f591528a0f1f11b1a4390949ab770f3f74a766f9)
+- Add range information to network-splits when splitting a network using `split.network.time.based.by.ranges`. This effect also propagates into `split.networks.time.based` (PR #274, 87911ade231c44b93be194a1d6734f7de043a4af)
+- Adjust `metrics.scale.freeness` and `metrics.is.scale.free` functions be compatible with both older and newer igraph versions (PR #274, 4b0d5221dd56bb3c9ddf196f67719d4f503d9b61)
 
 ## 4.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ### Announcement
 
-- Coronet is not compatible anymore with igraph versions below 2.1.0. This is due to the simultaneous deprecation of `subgraph.edges` and the introduction of the replacement for it, `subgraph_from_edges`, in igraph version 2.1.0.
+- Coronet is not compatible with `igraph` versions below 2.1.0 anymore. This is due to the simultaneous deprecation of `subgraph.edges` and the introduction of the replacement for it, `subgraph_from_edges`, in igraph version 2.1.0.
 
 ### Added
 
@@ -22,20 +22,21 @@
 
 ### Changed/Improved
 
-- **Breaking Change**: Change the default representation of edge attributes from vectors to lists. This change is necessary for the interplay of coronet networks with certain igraph functionality since igraph version 2.1. (PR #274, 1c35d1fa2548deb297dbfa5e2b07fce31962c5b7, eda30b838369ec46376812298a3ea8159eec5789, 44c7b72e3234cb332bb2713fb408c124e67255d9, 7303eabef6a78198575fe5bdfc02813fde3d3974)
+- **Breaking Change**: Change the default representation of edge attributes from vectors to lists. This change is necessary for the interplay of coronet networks with certain `igraph` functionality since igraph version 2.1.0 (PR #274, 1c35d1fa2548deb297dbfa5e2b07fce31962c5b7, eda30b838369ec46376812298a3ea8159eec5789, 0c6b2eba79b37f8ef2af7ffc41d86f1f307581bf, 44c7b72e3234cb332bb2713fb408c124e67255d9, 7303eabef6a78198575fe5bdfc02813fde3d3974, 0c27012641d24e19e5fa037406b480034c93f1aa)
 - Change the default value for the `issues.from.source` configuration parameter. Instead of reading JIRA and GitHub issues together, which was the previous default, the new default value causes only GitHub issue data to be read. To restore the previous default behavior and read data from both issue sources, this now needs to be manually configured when needed. (PR #264, 5ff83c364f6bfc1e6ff95e9c5f1087e031c48a5d, 8c8080cb9caf115f19d9f145ad6e6c108b131a67, 8bcbc81db521877908d2e5c2989082ed672f2a3b)
 - Replace deprecated `igraph` functions by their preferred alternatives (PR #264, PR #268, PR #274, 0df9d5bf6bafbb5d440f4c47db4ec901cf11f037, 7ac840d287a862eff61b1a84e194a4cba399f9e5, e3617b8c6b21fb4242c1d392124813501069ca84, 4b0d5221dd56bb3c9ddf196f67719d4f503d9b61)
 - Deprecate support for R version 3.6 (PR #264, c8e6f45111e487fadbe7f0a13c7595eb23f3af6e, fb3f5474259d4a88f4ff545691cca9d1ccde90e3)
 - Explicitly add R version 4.4 to the CI test pipeline (c8e6f45111e487fadbe7f0a13c7595eb23f3af6e)
 - Refactor function `construct.edge.list.from.key.value.list` to be more readable (PR #263, 05c3bc09cb1d396fd59c34a88030cdca58fd04dd)
+- Update necessary `igraph` version to 2.1.0 in `README.md` (PR #274, 6c3bcd1a2366d0d3a176d9fde95b8356b0158da3)
 
 ### Fixed
 
 - Fix the creation of edgelists for issue-based artifact-networks by correctly iterating over the issue data (PR #264, 321d85043112971c04998249c14a0677a32c9004)
 - Fix a bug in `extract.timestamps` that occurs when the first `data.source` contains empty data and that leads to a return value of type numeric which should be POSIXct (PR #270, 10696e4cf4ae92371917ed8ccaec2b0183da145c, 646c01a42ad8decfbc9040030e790e51cb65cffd)
-- Fix `read.commit.interactions` by explicitly considering non-existent commit interaction data (PR #274, f591528a0f1f11b1a4390949ab770f3f74a766f9)
+- Fix `read.commit.interactions` by explicitly considering non-existent commit interactions (PR #274, f591528a0f1f11b1a4390949ab770f3f74a766f9)
 - Add range information to network-splits when splitting a network using `split.network.time.based.by.ranges`. This effect also propagates into `split.networks.time.based` (PR #274, 87911ade231c44b93be194a1d6734f7de043a4af)
-- Adjust `metrics.scale.freeness` and `metrics.is.scale.free` functions be compatible with both older and newer igraph versions (PR #274, 4b0d5221dd56bb3c9ddf196f67719d4f503d9b61)
+- Adjust `metrics.scale.freeness` and `metrics.is.scale.free` functions to be compatible with both older and newer igraph versions (PR #274, 4b0d5221dd56bb3c9ddf196f67719d4f503d9b61)
 
 ## 4.4
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Alternatively, you can run `Rscript install.R` to install the packages.
 
 - `yaml`: To read YAML configuration files (i.e., Codeface configuration files)
 - `R6`: For proper classes
-- `igraph`: For the construction of networks (package version `1.3.0` or higher is recommended)
+- `igraph`: For the construction of networks (package version `2.1.0` or higher is required)
 - `plyr`: For the `dlply` splitting-function and `rbind.fill`
 - `parallel`: For parallelization
 - `logging`: Logging

--- a/showcase.R
+++ b/showcase.R
@@ -404,7 +404,7 @@ plot.network(g.simplified)
 
 ## construct sample network for plotting
 g = get.sample.network()
-g = igraph::as.directed(g, mode = "arbitrary")
+g = igraph::as_directed(g, mode = "arbitrary")
 g = g + igraph::edges("A6", "A5", type = TYPE.EDGES.INTRA, weight = 2,
                       relation = "callgraph", artifact.type = "Feature")
 g = simplify.network(g)

--- a/tests/test-networks-artifact.R
+++ b/tests/test-networks-artifact.R
@@ -57,6 +57,7 @@ test_that("Network construction of the undirected artifact-cochange network", {
     )
     ## 3) build expected network
     network.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
 
     ##
@@ -158,6 +159,7 @@ patrick::with_parameters_test_that("Network construction of an issue-based artif
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     ## build network
     network.built = network.builder$get.artifact.network()
@@ -207,6 +209,7 @@ patrick::with_parameters_test_that("Network construction of an empty 'comments-o
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     ## test
     assert.networks.equal(network.built, network.expected)
@@ -258,6 +261,7 @@ patrick::with_parameters_test_that("Network construction with commit-interaction
         relation = c("commit.interaction", "commit.interaction", "commit.interaction", "commit.interaction")
         )
     network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network = convert.edge.attributes.to.list(network)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(
@@ -308,6 +312,7 @@ patrick::with_parameters_test_that("Network construction with commit-interaction
         relation = c("commit.interaction", "commit.interaction", "commit.interaction", "commit.interaction")
         )
     network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network = convert.edge.attributes.to.list(network)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(

--- a/tests/test-networks-author.R
+++ b/tests/test-networks-author.R
@@ -232,6 +232,7 @@ test_that("Network construction of the undirected author-cochange network", {
     )
     ## 3) build expected network
     network.expected = igraph::graph_from_data_frame(data, directed = FALSE, vertices = authors)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
 
     ##
@@ -316,6 +317,7 @@ test_that("Network construction of the undirected but temorally ordered author-c
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(data, directed = FALSE, vertices = authors)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -357,6 +359,7 @@ test_that("Network construction of the directed author-cochange network", {
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(data, directed = TRUE, vertices = authors)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -403,6 +406,7 @@ test_that("Network construction of the directed author-cochange network without 
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(data, directed = TRUE, vertices = authors)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -431,25 +435,26 @@ test_that("Network construction of the undirected simplified author-cochange net
     date.attr = igraph::edge_attr(network.built, "date")
     date.conversion.function = ifelse(all(sapply(date.attr, lubridate::is.POSIXct)),
                                       get.date.from.unix.timestamp, identity)
+    date.conversion.function = get.date.from.unix.timestamp
 
     ## edge attributes
     data = data.frame(
         from = c("Björn", "Olaf", "Olaf", "Karl"),
         to = c("Olaf", "Karl", "Thomas", "Thomas"),
-        date = I(list(date.conversion.function(c(1468339139, 1468339245)),
-                      date.conversion.function(c(1468339541, 1468339570)),
-                      date.conversion.function(c(1468339541, 1468339592)),
-                      date.conversion.function(c(1468339570, 1468339592)))),
-        artifact.type = I(list(c("Feature", "Feature"), c("Feature", "Feature"), c("Feature", "Feature"),
-                               c("Feature", "Feature"))),
+        date = I(list(as.list(date.conversion.function(c(1468339139, 1468339245))),
+                      as.list(date.conversion.function(c(1468339541, 1468339570))),
+                      as.list(date.conversion.function(c(1468339541, 1468339592))),
+                      as.list(date.conversion.function(c(1468339570, 1468339592))))),
+        artifact.type = I(list(list("Feature", "Feature"), list("Feature", "Feature"), list("Feature", "Feature"),
+                               list("Feature", "Feature"))),
         hash = I(list(
-            c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338"),
-            c("3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61"),
-            c("3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526"),
-            c("1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526"))),
-        file = I(list(c("test.c", "test.c"), c("test2.c", "test3.c"), c("test2.c", "test2.c"), c("test3.c", "test2.c"))),
-        artifact = I(list(c("A", "A"), c("Base_Feature", "Base_Feature"), c("Base_Feature", "Base_Feature"),
-                          c("Base_Feature", "Base_Feature"))),
+            list("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338"),
+            list("3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61"),
+            list("3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526"),
+            list("1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526"))),
+        file = I(list(list("test.c", "test.c"), list("test2.c", "test3.c"), list("test2.c", "test2.c"), list("test3.c", "test2.c"))),
+        artifact = I(list(list("A", "A"), list("Base_Feature", "Base_Feature"), list("Base_Feature", "Base_Feature"),
+                          list("Base_Feature", "Base_Feature"))),
         weight = 2,
         type = TYPE.EDGES.INTRA,
         relation = "cochange"
@@ -589,6 +594,7 @@ test_that("Network construction of the undirected author-issue network with all 
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -649,6 +655,7 @@ test_that("Network construction of the undirected author-issue network with just
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -677,6 +684,7 @@ test_that("Network construction with only untracked files (no edges expected)", 
     vertices = list(name = c("Karl", "Thomas"), kind = TYPE.AUTHOR, type = TYPE.AUTHOR)
     network.expected = create.empty.network(directed = FALSE, add.attributes = TRUE)
     network.expected = igraph::add_vertices(network.expected, nv = max(lengths(vertices)), attr = vertices)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     ## test
     expect_true(igraph::identical_graphs(network.built, network.expected))
@@ -726,6 +734,7 @@ patrick::with_parameters_test_that("Network construction with commit-interaction
         relation = c("commit.interaction", "commit.interaction", "commit.interaction", "commit.interaction")
         )
     network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network = convert.edge.attributes.to.list(network)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(

--- a/tests/test-networks-bipartite.R
+++ b/tests/test-networks-bipartite.R
@@ -84,6 +84,7 @@ test_that("Construction of the bipartite network for the feature artifact with a
     ## 3) construct expected network
     network.expected = igraph::graph_from_data_frame(network.expected.data, vertices = vertices,
                                                 directed = net.conf$get.value("author.directed"))
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -137,6 +138,7 @@ test_that("Construction of the bipartite network for the file artifact with auth
               ## 3) construct expected network
               network.expected = igraph::graph_from_data_frame(network.expected.data, vertices = vertices,
                                                           directed = net.conf$get.value("author.directed"))
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -189,6 +191,7 @@ test_that("Construction of the bipartite network for the function artifact with 
               )
               ## 3) construct expected network
               network.expected = igraph::graph_from_data_frame(network.expected.data, directed = net.conf$get.value("author.directed"), vertices = vertices)
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -240,6 +243,7 @@ test_that("Construction of the bipartite network for the featureexpression artif
               ## 3) construct expected network
               network.expected = igraph::graph_from_data_frame(network.expected.data, vertices = vertices,
                                                           directed = net.conf$get.value("author.directed"))
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -309,6 +313,7 @@ test_that("Construction of the bipartite network for the feature artifact with a
               )
               ## 3) construct expected network
               network.expected = igraph::graph_from_data_frame(network.expected.data, directed = net.conf$get.value("author.directed"), vertices = vertices)
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -362,6 +367,7 @@ test_that("Construction of the directed bipartite network for the feature artifa
               ## 3) construct expected network
               network.expected = igraph::graph_from_data_frame(network.expected.data, vertices = vertices,
                                                           directed = net.conf$get.value("author.directed"))
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -415,6 +421,7 @@ test_that("Construction of the directed bipartite network for the file artifact 
               ## 3) construct expected network
               network.expected = igraph::graph_from_data_frame(network.expected.data, vertices = vertices,
                                                           directed = net.conf$get.value("author.directed"))
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -469,6 +476,7 @@ test_that("Construction of the directed bipartite network for the function artif
               ## 3) construct expected network
               network.expected = igraph::graph_from_data_frame(network.expected.data, vertices = vertices,
                                                           directed = net.conf$get.value("author.directed"))
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -521,6 +529,7 @@ test_that("Construction of the directed bipartite network for the featureexpress
               ## 3) construct expected network
               network.expected = igraph::graph_from_data_frame(network.expected.data, vertices = vertices,
                                                           directed = net.conf$get.value("author.directed"))
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               expect_true(igraph::identical_graphs(network.built, network.expected))
 })
@@ -563,6 +572,7 @@ test_that("Network construction with only untracked files (no edges and artifact
                                                         directed = net.conf$get.value("author.directed"))
     ## 4) remove edge again
     network.expected = igraph::delete_edges(network.expected, 1)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     ## test
     expect_true(igraph::identical_graphs(network.built, network.expected))

--- a/tests/test-networks-commit.R
+++ b/tests/test-networks-commit.R
@@ -83,6 +83,7 @@ patrick::with_parameters_test_that("Network construction with commit-interaction
         relation = c("commit.interaction", "commit.interaction", "commit.interaction", "commit.interaction")
         )
     network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network = convert.edge.attributes.to.list(network)
     expect_true(igraph::identical_graphs(network.built, network))
 
     network.new.attr = add.vertex.attribute.commit.network(network.built, proj.data,  "deleted.lines", "NO_DATA")
@@ -133,6 +134,7 @@ patrick::with_parameters_test_that("Network construction with cochange as relati
         edges <- edges[, c(2, 1, 3, 4, 5, 6, 7, 8), ]
     }
     network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network = convert.edge.attributes.to.list(network)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(
@@ -188,6 +190,7 @@ patrick::with_parameters_test_that("Network construction with cochange as relati
         edges <- edges[, c(2, 1, 3, 4, 5, 6, 7, 8), ]
     }
     network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network = convert.edge.attributes.to.list(network)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(
@@ -239,6 +242,7 @@ patrick::with_parameters_test_that("Network construction with cochange as relati
         edges <- edges[, c(2, 1, 3, 4, 5, 6, 7, 8), ]
     }
     network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
+    network = convert.edge.attributes.to.list(network)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(
@@ -293,6 +297,7 @@ test_that("Adding vertex attributes to a commit network", {
         )
 
     network = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
+    network = convert.edge.attributes.to.list(network)
 
     expect_true(igraph::identical_graphs(network.new.attr, network))
 
@@ -334,6 +339,7 @@ test_that("Adding vertex attributes to a commit network", {
         )
 
     network.two = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
+    network.two = convert.edge.attributes.to.list(network.two)
 
     expect_true(igraph::identical_graphs(network.new.attr, network.two))
 })

--- a/tests/test-networks-commit.R
+++ b/tests/test-networks-commit.R
@@ -12,6 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
+## Copyright 2024 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
 
 ## All Rights Reserved.
 
@@ -81,7 +82,7 @@ patrick::with_parameters_test_that("Network construction with commit-interaction
         type = c(TYPE.EDGES.INTRA, TYPE.EDGES.INTRA, TYPE.EDGES.INTRA, TYPE.EDGES.INTRA),
         relation = c("commit.interaction", "commit.interaction", "commit.interaction", "commit.interaction")
         )
-    network = igraph::graph.data.frame(edges, directed = test.directed, vertices = vertices)
+    network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
     expect_true(igraph::identical_graphs(network.built, network))
 
     network.new.attr = add.vertex.attribute.commit.network(network.built, proj.data,  "deleted.lines", "NO_DATA")
@@ -131,7 +132,7 @@ patrick::with_parameters_test_that("Network construction with cochange as relati
     if (test.directed) {
         edges <- edges[, c(2, 1, 3, 4, 5, 6, 7, 8), ]
     }
-    network = igraph::graph.data.frame(edges, directed = test.directed, vertices = vertices)
+    network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(
@@ -186,7 +187,7 @@ patrick::with_parameters_test_that("Network construction with cochange as relati
     if (test.directed) {
         edges <- edges[, c(2, 1, 3, 4, 5, 6, 7, 8), ]
     }
-    network = igraph::graph.data.frame(edges, directed = test.directed, vertices = vertices)
+    network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(
@@ -237,7 +238,7 @@ patrick::with_parameters_test_that("Network construction with cochange as relati
     if (test.directed) {
         edges <- edges[, c(2, 1, 3, 4, 5, 6, 7, 8), ]
     }
-    network = igraph::graph.data.frame(edges, directed = test.directed, vertices = vertices)
+    network = igraph::graph_from_data_frame(edges, directed = test.directed, vertices = vertices)
 
     expect_true(igraph::identical_graphs(network.built, network))
 }, patrick::cases(
@@ -291,7 +292,7 @@ test_that("Adding vertex attributes to a commit network", {
         relation = c("cochange", "cochange", "cochange", "cochange")
         )
 
-    network = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    network = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
 
     expect_true(igraph::identical_graphs(network.new.attr, network))
 
@@ -332,7 +333,7 @@ test_that("Adding vertex attributes to a commit network", {
         relation = c("cochange", "cochange", "cochange", "cochange")
         )
 
-    network.two = igraph::graph.data.frame(edges, directed = FALSE, vertices = vertices)
+    network.two = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
 
     expect_true(igraph::identical_graphs(network.new.attr, network.two))
 })

--- a/tests/test-networks-equal-constructions.R
+++ b/tests/test-networks-equal-constructions.R
@@ -42,12 +42,12 @@ compare.edge.and.vertex.lists = function(split.networks.one, split.networks.two)
     for (i in seq_along(split.networks.one)) {
         edges.one = igraph::as_data_frame(split.networks.one[[i]], what = "edges")
         ordering = order(edges.one[["from"]], edges.one[["to"]],
-                         edges.one[["date"]])
+                         as.vector(edges.one[["date"]], "numeric"))
         edges.one = edges.one[ordering, ]
         rownames(edges.one) = seq_len(nrow(edges.one))
         edges.two = igraph::as_data_frame(split.networks.two[[i]], what = "edges")
         ordering = order(edges.two[["from"]], edges.two[["to"]],
-                         edges.two[["date"]])
+                         as.vector(edges.two[["date"]], "numeric"))
         edges.two = edges.two[ordering, ]
         rownames(edges.two) = seq_len(nrow(edges.two))
         vertices.one = igraph::as_data_frame(split.networks.one[[i]], what = "vertices")

--- a/tests/test-networks-multi-relation.R
+++ b/tests/test-networks-multi-relation.R
@@ -63,33 +63,43 @@ test_that("Network construction of the undirected author network with relation =
                                   "Björn", "Björn", "Olaf",  "Olaf"), # mail
                       comb.2. = c("Olaf", "Olaf", "Karl", "Karl", "Thomas", "Thomas", "Thomas", "Thomas", # cochange
                                   "Olaf", "Olaf", "Thomas", "Thomas"), # mail
-                      date = get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45", "2016-07-12 16:05:41", # cochange
-                                                    "2016-07-12 16:06:10", "2016-07-12 16:05:41", "2016-07-12 16:06:32",
-                                                    "2016-07-12 16:06:10",   "2016-07-12 16:06:32",
-                                                    "2016-07-12 15:58:40", "2016-07-12 15:58:50", "2016-07-12 16:04:40", # mail
-                                                    "2016-07-12 16:05:37")),
-                      artifact.type = c(rep("Feature", 8), # cochange
-                                        rep("Mail", 4)), # mail
-                      hash = c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338",
-                               "3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61",
-                               "3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526",
-                               "1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526",
-                               rep(NA, 4)),
-                      file = c("test.c", "test.c", "test2.c", "test3.c", "test2.c", "test2.c", "test3.c", "test2.c",
-                               rep(NA, 4)),
-                      artifact = c("A", "A", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature",
-                                   rep(NA, 4)),
+                      date = I(as.list(get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45", "2016-07-12 16:05:41", # cochange
+                                                              "2016-07-12 16:06:10", "2016-07-12 16:05:41", "2016-07-12 16:06:32",
+                                                              "2016-07-12 16:06:10",   "2016-07-12 16:06:32",
+                                                              "2016-07-12 15:58:40", "2016-07-12 15:58:50", "2016-07-12 16:04:40", # mail
+                                                              "2016-07-12 16:05:37")))),
+                      artifact.type = I(c(as.list(rep("Feature", 8)), # cochange
+                                          as.list(rep("Mail", 4)))), # mail
+                      hash = I(c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338",
+                                 "3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61",
+                                 "3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526",
+                                 "1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526",
+                                 as.list(rep(NA, 4)))),
+                      file = I(c("test.c", "test.c", "test2.c", "test3.c", "test2.c", "test2.c", "test3.c", "test2.c",
+                                 as.list(rep(NA, 4)))),
+                      artifact = I(c("A", "A", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature",
+                                     as.list(rep(NA, 4)))),
                       weight = 1,
                       type = TYPE.EDGES.INTRA,
                       relation = c(rep("cochange", 8),
                                    rep("mail", 4)),
-                      message.id = c(NA, NA, NA, NA, NA, NA, NA, NA,
-                                     "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
-                                     "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
-                                     "<65a1sf31sagd684dfv31@mail.gmail.com>", "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>"),
-                      thread = c(NA, NA, NA, NA, NA, NA, NA, NA,
-                                 "<thread-13#8>", "<thread-13#8>", "<thread-13#9>", "<thread-13#9>")
+                      message.id = I(c(as.list(rep(NA, 8)),
+                                       "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
+                                       "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
+                                       "<65a1sf31sagd684dfv31@mail.gmail.com>",
+                                       "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>")),
+                      thread = I(c(as.list(rep(NA, 8)),
+                                   "<thread-13#8>", "<thread-13#8>", "<thread-13#9>", "<thread-13#9>"))
     )
+
+    ## remove the 'AsIs' class from the edge attributes that have been inserted via `I(...)`
+    data[["date"]] = unclass(data[["date"]])
+    data[["artifact.type"]] = unclass(data[["artifact.type"]])
+    data[["hash"]] = unclass(data[["hash"]])
+    data[["file"]] = unclass(data[["file"]])
+    data[["artifact"]] = unclass(data[["artifact"]])
+    data[["message.id"]] = unclass(data[["message.id"]])
+    data[["thread"]] = unclass(data[["thread"]])
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(data, vertices = authors,
@@ -156,47 +166,55 @@ test_that("Construction of the bipartite network for the feature artifact with a
                            "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>", "<thread-42#5>", "<thread-42#6>", "<thread-42#6>", # mail
                            "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#7>", "<thread-13#8>", "<thread-13#9>",
                            "<thread-13#9>", "<thread-13#3>"),
-                  date = get.date.from.string(c("2013-05-05 21:46:30", "2013-05-05 21:49:21", "2013-05-05 21:49:34", # issue
-                                                "2013-05-06 01:04:34", "2013-05-25 03:48:41", "2013-05-25 04:08:07",
-                                                "2016-07-12 14:59:25", "2016-07-12 16:02:30", "2016-07-12 16:06:01",
-                                                "2016-07-15 19:55:39", "2017-05-23 12:32:39", "2016-07-12 15:59:59",
-                                                "2016-07-15 20:07:47", "2016-07-27 20:12:08", "2016-07-28 06:27:52",
-                                                "2013-05-25 03:25:06", "2013-05-25 06:06:53", "2013-05-25 06:22:23",
-                                                "2013-06-01 06:50:26", "2016-07-12 16:01:01", "2016-07-12 16:02:02",
-                                                "2013-04-21 23:52:09", "2016-07-12 15:59:25", "2016-07-12 16:03:59",
-                                                "2004-10-09 18:38:13", "2005-02-09 18:49:49", "2016-07-12 15:58:40", # mail
-                                                "2010-07-12 11:05:35", "2010-07-12 12:05:34", "2010-07-12 12:05:40",
-                                                "2010-07-12 12:05:41", "2010-07-12 12:05:42", "2010-07-12 12:05:43",
-                                                "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2010-07-12 12:05:46",
-                                                "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:04:40",
-                                                "2010-07-12 10:05:36")),
-                  artifact.type = c(rep("IssueEvent", 24), rep("Mail", 16)),
-                  message.id = c(rep(NA, 24),
-                                 "<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>", "<1107974989.17910.6.camel@jmcmullan>",
-                                 "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
-                                 "<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>", "<dfhglkjdgjkhnwrd@mail.gmail.com>",
-                                 "<hans1@mail.gmail.com>", "<hans2@mail.gmail.com>", "<hans3@mail.gmail.com>",
-                                 "<hans4@mail.gmail.com>", "<hans5@mail.gmail.com>", "<hans6@mail.gmail.com>",
-                                 "<hans7@mail.gmail.com>", "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
-                                 "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>", "<65a1sf31sagd684dfv31@mail.gmail.com>",
-                                 "<asddghdswqeasdasd@mail.gmail.com>"),
-                  thread = c(rep(NA, 24),
-                             "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>", "<thread-42#5>", "<thread-42#6>",
-                             "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#7>",
-                             "<thread-13#8>", "<thread-13#9>", "<thread-13#9>", "<thread-13#3>"),
-                  issue.id = c("<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", # issue
-                               "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                               "<issue-github-2>", "<issue-jira-ZEPPELIN-332>", "<issue-github-1>", "<issue-jira-ZEPPELIN-332>", "<issue-github-6>",
-                               "<issue-github-3>", "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>",
-                               "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                               "<issue-github-1>", "<issue-github-4>", "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-6>",
-                               rep(NA,16)),
-                  event.name = c(rep("commented", 24),
-                                 rep(NA, 16)),
+                  date = I(as.list(get.date.from.string(c("2013-05-05 21:46:30", "2013-05-05 21:49:21", "2013-05-05 21:49:34", # issue
+                                                          "2013-05-06 01:04:34", "2013-05-25 03:48:41", "2013-05-25 04:08:07",
+                                                          "2016-07-12 14:59:25", "2016-07-12 16:02:30", "2016-07-12 16:06:01",
+                                                          "2016-07-15 19:55:39", "2017-05-23 12:32:39", "2016-07-12 15:59:59",
+                                                          "2016-07-15 20:07:47", "2016-07-27 20:12:08", "2016-07-28 06:27:52",
+                                                          "2013-05-25 03:25:06", "2013-05-25 06:06:53", "2013-05-25 06:22:23",
+                                                          "2013-06-01 06:50:26", "2016-07-12 16:01:01", "2016-07-12 16:02:02",
+                                                          "2013-04-21 23:52:09", "2016-07-12 15:59:25", "2016-07-12 16:03:59",
+                                                          "2004-10-09 18:38:13", "2005-02-09 18:49:49", "2016-07-12 15:58:40", # mail
+                                                          "2010-07-12 11:05:35", "2010-07-12 12:05:34", "2010-07-12 12:05:40",
+                                                          "2010-07-12 12:05:41", "2010-07-12 12:05:42", "2010-07-12 12:05:43",
+                                                          "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2010-07-12 12:05:46",
+                                                          "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:04:40",
+                                                          "2010-07-12 10:05:36")))),
+                  artifact.type = I(c(as.list(rep("IssueEvent", 24)), as.list(rep("Mail", 16)))),
+                  message.id = I(c(as.list(rep(NA, 24)),
+                                   "<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>", "<1107974989.17910.6.camel@jmcmullan>",
+                                   "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
+                                   "<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>", "<dfhglkjdgjkhnwrd@mail.gmail.com>",
+                                   "<hans1@mail.gmail.com>", "<hans2@mail.gmail.com>", "<hans3@mail.gmail.com>",
+                                   "<hans4@mail.gmail.com>", "<hans5@mail.gmail.com>", "<hans6@mail.gmail.com>",
+                                   "<hans7@mail.gmail.com>", "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
+                                   "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>", "<65a1sf31sagd684dfv31@mail.gmail.com>",
+                                   "<asddghdswqeasdasd@mail.gmail.com>")),
+                  thread = I(c(as.list(rep(NA, 24)),
+                               "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>", "<thread-42#5>", "<thread-42#6>",
+                               "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#7>",
+                               "<thread-13#8>", "<thread-13#9>", "<thread-13#9>", "<thread-13#3>")),
+                  issue.id = I(c("<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", # issue
+                                 "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                                 "<issue-github-2>", "<issue-jira-ZEPPELIN-332>", "<issue-github-1>", "<issue-jira-ZEPPELIN-332>", "<issue-github-6>",
+                                 "<issue-github-3>", "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>",
+                                 "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                                 "<issue-github-1>", "<issue-github-4>", "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-6>",
+                                 as.list(rep(NA,16)))),
+                  event.name = I(c(rep("commented", 24),
+                                   as.list(rep(NA, 16)))),
                   weight = 1,
                   type = TYPE.EDGES.INTER,
                   relation = c(rep("issue", 24), rep("mail", 16))
     )
+
+    ## remove the 'AsIs' class from the edge attributes that have been inserted via `I(...)`
+    network.expected.data[["date"]]       = unclass(network.expected.data[["date"]])
+    network.expected.data[["artifact.type"]] = unclass(network.expected.data[["artifact.type"]])
+    network.expected.data[["message.id"]] = unclass(network.expected.data[["message.id"]])
+    network.expected.data[["thread"]]     = unclass(network.expected.data[["thread"]])
+    network.expected.data[["issue.id"]]   = unclass(network.expected.data[["issue.id"]])
+    network.expected.data[["event.name"]] = unclass(network.expected.data[["event.name"]])
 
     ## 3) build expected network
     network.expected = igraph::graph_from_data_frame(network.expected.data, vertices = vertices,
@@ -251,65 +269,77 @@ test_that("Construction of the multi network for the feature artifact with autho
                               "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-github-2>", "<issue-jira-ZEPPELIN-332>", "<issue-github-1>", "<issue-jira-ZEPPELIN-332>",
                               "<issue-github-6>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
                               "<issue-github-1>", "<issue-github-4>", "<issue-github-3>", "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-6>"),
-                       date = get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45", "2016-07-12 16:05:41", # author cochange
-                                                     "2016-07-12 16:06:10", "2016-07-12 16:05:41", "2016-07-12 16:06:32",
-                                                     "2016-07-12 16:06:10", "2016-07-12 16:06:32",
-                                                     "2016-07-12 15:58:40", "2016-07-12 15:58:50", "2016-07-12 16:04:40",
-                                                     "2016-07-12 16:05:37",
-                                                     "2016-07-12 16:06:32",                        # artifact cochange
-                                                     "2016-07-12 15:58:59", "2016-07-12 16:00:45", "2016-07-12 16:05:41", # bipartite cochange
-                                                     "2016-07-12 16:06:10", "2016-07-12 16:06:32", "2016-07-12 16:06:32",
-                                                     "2013-05-05 21:46:30", "2013-05-05 21:49:21", "2013-05-05 21:49:34", # bipartite issue
-                                                     "2013-05-06 01:04:34", "2013-05-25 03:48:41", "2013-05-25 04:08:07", "2016-07-12 14:59:25",
-                                                     "2016-07-12 16:02:30", "2016-07-12 16:06:01", "2016-07-15 19:55:39", "2017-05-23 12:32:39",
-                                                     "2013-05-25 03:25:06", "2013-05-25 06:06:53", "2013-05-25 06:22:23",
-                                                     "2013-06-01 06:50:26", "2016-07-12 16:01:01", "2016-07-12 16:02:02",
-                                                     "2016-07-12 15:59:59", "2013-04-21 23:52:09", "2016-07-12 15:59:25",
-                                                     "2016-07-12 16:03:59")),
-                        artifact.type = c(rep("Feature", 8), rep("Mail", 4), rep("Feature", 1), rep("Feature", 6),
-                                          rep("IssueEvent", 21)),
-                        hash = c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338", # author cochange
-                                 "3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61",
-                                 "3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526",
-                                 "1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526",
-                                 NA, NA, NA, NA,                                                                         # author mail
-                                 "0a1a5c523d835459c42f33e863623138555e2526", # artifact cochange
-                                 "72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338", # bipartite cochange
-                                 "3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61",
-                                 "0a1a5c523d835459c42f33e863623138555e2526", "0a1a5c523d835459c42f33e863623138555e2526",
-                                 rep(NA, 21)),                                                                           # bipartite issue
-                        file = c("test.c", "test.c", "test2.c", "test3.c", "test2.c", "test2.c", "test3.c", "test2.c", # author cochange
-                                 NA, NA, NA, NA,
-                                 "test2.c",                                                                             # artifact cochange
-                                 "test.c", "test.c", "test2.c", "test3.c", "test2.c", "test2.c",                       # bipartite cochange
-                                 rep(NA, 21)),
-                        artifact = c("A", "A", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", # author cochange
-                                     "Base_Feature",
-                                     rep(NA, 4),
-                                     NA, # artifact cochange
-                                     "A", "A", "Base_Feature", "Base_Feature", "Base_Feature", "foo", # bipartite cochange
-                                     rep(NA, 21)),
-                        weight = 1,
-                        type = c(rep(TYPE.EDGES.INTRA, 13), rep(TYPE.EDGES.INTER, 27)),
-                        relation = c(rep("cochange", 8), rep("mail", 4), rep("cochange", 1), rep("cochange", 6),
-                                     rep("issue", 21)),
-                        message.id = c(rep(NA, 8),
-                                       "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
-                                       "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
-                                       "<65a1sf31sagd684dfv31@mail.gmail.com>",
-                                       "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>",
-                                       rep(NA, 28)),
-                        thread = c(rep(NA, 8),
-                                   "<thread-13#8>", "<thread-13#8>", "<thread-13#9>", "<thread-13#9>",
-                                   rep(NA, 28)),
-                        author.name = c(rep(NA, 12), "Thomas", rep(NA, 27)),
-                        issue.id = c(rep(NA, 19),
-                                     "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", # bipartite issue
-                                     "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-github-2>", "<issue-jira-ZEPPELIN-332>", "<issue-github-1>", "<issue-jira-ZEPPELIN-332>",
-                                     "<issue-github-6>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                                     "<issue-github-1>", "<issue-github-4>", "<issue-github-3>", "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-6>"),
-                        event.name = c(rep(NA, 19), rep("commented", 21))
+                       date = I(as.list(get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45", "2016-07-12 16:05:41", # author cochange
+                                                               "2016-07-12 16:06:10", "2016-07-12 16:05:41", "2016-07-12 16:06:32",
+                                                               "2016-07-12 16:06:10", "2016-07-12 16:06:32",
+                                                               "2016-07-12 15:58:40", "2016-07-12 15:58:50", "2016-07-12 16:04:40",
+                                                               "2016-07-12 16:05:37",
+                                                               "2016-07-12 16:06:32",                        # artifact cochange
+                                                               "2016-07-12 15:58:59", "2016-07-12 16:00:45", "2016-07-12 16:05:41", # bipartite cochange
+                                                               "2016-07-12 16:06:10", "2016-07-12 16:06:32", "2016-07-12 16:06:32",
+                                                               "2013-05-05 21:46:30", "2013-05-05 21:49:21", "2013-05-05 21:49:34", # bipartite issue
+                                                               "2013-05-06 01:04:34", "2013-05-25 03:48:41", "2013-05-25 04:08:07", "2016-07-12 14:59:25",
+                                                               "2016-07-12 16:02:30", "2016-07-12 16:06:01", "2016-07-15 19:55:39", "2017-05-23 12:32:39",
+                                                               "2013-05-25 03:25:06", "2013-05-25 06:06:53", "2013-05-25 06:22:23",
+                                                               "2013-06-01 06:50:26", "2016-07-12 16:01:01", "2016-07-12 16:02:02",
+                                                               "2016-07-12 15:59:59", "2013-04-21 23:52:09", "2016-07-12 15:59:25",
+                                                               "2016-07-12 16:03:59")))),
+                       artifact.type = I(c(as.list(rep("Feature", 8)), as.list(rep("Mail", 4)), as.list(rep("Feature", 1)), as.list(rep("Feature", 6)),
+                                           as.list(rep("IssueEvent", 21)))),
+                       hash = I(c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338", # author cochange
+                                  "3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61",
+                                  "3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526",
+                                  "1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526",
+                                  as.list(rep(NA, 4)),                                                                    # author mail
+                                  "0a1a5c523d835459c42f33e863623138555e2526", # artifact cochange
+                                  "72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338", # bipartite cochange
+                                  "3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61",
+                                  "0a1a5c523d835459c42f33e863623138555e2526", "0a1a5c523d835459c42f33e863623138555e2526",
+                                  as.list(rep(NA, 21)))),                                                                 # bipartite issue
+                       file = I(c("test.c", "test.c", "test2.c", "test3.c", "test2.c", "test2.c", "test3.c", "test2.c",   # author cochange
+                                  as.list(rep(NA, 4)),
+                                  "test2.c",                                                                              # artifact cochange
+                                  "test.c", "test.c", "test2.c", "test3.c", "test2.c", "test2.c",                         # bipartite cochange
+                                  as.list(rep(NA, 21)))),
+                       artifact = I(c("A", "A", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", # author cochange
+                                      "Base_Feature",
+                                      as.list(rep(NA, 4)),
+                                      NA, # artifact cochange
+                                      "A", "A", "Base_Feature", "Base_Feature", "Base_Feature", "foo", # bipartite cochange
+                                      as.list(rep(NA, 21)))),
+                       weight = 1,
+                       type = c(rep(TYPE.EDGES.INTRA, 13), rep(TYPE.EDGES.INTER, 27)),
+                       relation = c(rep("cochange", 8), rep("mail", 4), rep("cochange", 1), rep("cochange", 6),
+                                    rep("issue", 21)),
+                       message.id = I(c(as.list(rep(NA, 8)),
+                                        "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
+                                        "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
+                                        "<65a1sf31sagd684dfv31@mail.gmail.com>",
+                                        "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>",
+                                        as.list(rep(NA, 28)))),
+                       thread = I(c(as.list(rep(NA, 8)),
+                                    "<thread-13#8>", "<thread-13#8>", "<thread-13#9>", "<thread-13#9>",
+                                    as.list(rep(NA, 28)))),
+                       author.name = I(c(as.list(rep(NA, 12)), "Thomas", as.list(rep(NA, 27)))),
+                       issue.id = I(c(as.list(rep(NA, 19)),
+                                      "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", # bipartite issue
+                                      "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-github-2>", "<issue-jira-ZEPPELIN-332>", "<issue-github-1>", "<issue-jira-ZEPPELIN-332>",
+                                      "<issue-github-6>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                                      "<issue-github-1>", "<issue-github-4>", "<issue-github-3>", "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-6>")),
+                       event.name = I(c(as.list(rep(NA, 19)), rep("commented", 21)))
      )
+
+    ## Remove the 'AsIs' class from the edge attributes that have been inserted via `I(...)`
+    edges[["date"]] = unclass(edges[["date"]])
+    edges[["artifact.type"]] = unclass(edges[["artifact.type"]])
+    edges[["hash"]] = unclass(edges[["hash"]])
+    edges[["file"]] = unclass(edges[["file"]])
+    edges[["artifact"]] = unclass(edges[["artifact"]])
+    edges[["message.id"]] = unclass(edges[["message.id"]])
+    edges[["thread"]] = unclass(edges[["thread"]])
+    edges[["author.name"]] = unclass(edges[["author.name"]])
+    edges[["issue.id"]] = unclass(edges[["issue.id"]])
+    edges[["event.name"]] = unclass(edges[["event.name"]])
 
     ## 3) build expected network
     network.expected = igraph::graph_from_data_frame(edges, vertices = vertices,
@@ -371,43 +401,51 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
                "<issue-jira-ZEPPELIN-328>","<issue-jira-ZEPPELIN-328>","<issue-jira-ZEPPELIN-328>",
                "<issue-jira-ZEPPELIN-328>","<issue-github-1>",         "<issue-github-4>",
                "<issue-jira-ZEPPELIN-328>","<issue-github-1>",         "<issue-github-6>"),
-        date = get.date.from.string(c("2016-07-12 15:58:59 UTC", "2016-07-12 16:06:10 UTC",
-                                      "2016-07-12 16:00:45 UTC", "2016-07-12 16:05:41 UTC",
-                                      "2016-07-12 16:06:32 UTC", "2016-07-12 16:06:32 UTC",
-                                      "2013-05-05 21:46:30 UTC", "2013-05-05 21:49:21 UTC",
-                                      "2013-05-05 21:49:34 UTC", "2013-05-06 01:04:34 UTC",
-                                      "2013-05-25 03:48:41 UTC", "2013-05-25 04:08:07 UTC",
-                                      "2016-07-12 14:59:25 UTC", "2016-07-12 16:02:30 UTC",
-                                      "2016-07-12 16:06:01 UTC", "2016-07-15 19:55:39 UTC",
-                                      "2017-05-23 12:32:39 UTC", "2016-07-12 15:59:59 UTC",
-                                      "2016-07-15 20:07:47 UTC", "2016-07-27 20:12:08 UTC",
-                                      "2016-07-28 06:27:52 UTC", "2013-05-25 03:25:06 UTC",
-                                      "2013-05-25 06:06:53 UTC", "2013-05-25 06:22:23 UTC",
-                                      "2013-06-01 06:50:26 UTC", "2016-07-12 16:01:01 UTC",
-                                      "2016-07-12 16:02:02 UTC", "2013-04-21 23:52:09 UTC",
-                                      "2016-07-12 15:59:25 UTC", "2016-07-12 16:03:59 UTC")),
-        artifact.type = c(rep("Feature", 6), rep("IssueEvent", 24)),
-        hash = c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "1143db502761379c2bfcecc2007fc34282e7ee61",
-                 "5a5ec9675e98187e1e92561e1888aa6f04faa338", "3a0ed78458b3976243db6829f63eba3eead26774",
-                 "0a1a5c523d835459c42f33e863623138555e2526", "0a1a5c523d835459c42f33e863623138555e2526",
-                 rep(NA, 24)),
-        file = c("test.c", "test3.c", "test.c", "test2.c", "test2.c", "test2.c", rep(NA, 24)),
-        artifact = c("A", "Base_Feature", "A", "Base_Feature", "Base_Feature", "foo", rep(NA, 24)),
+        date = I(as.list(get.date.from.string(c("2016-07-12 15:58:59 UTC", "2016-07-12 16:06:10 UTC",
+                                                "2016-07-12 16:00:45 UTC", "2016-07-12 16:05:41 UTC",
+                                                "2016-07-12 16:06:32 UTC", "2016-07-12 16:06:32 UTC",
+                                                "2013-05-05 21:46:30 UTC", "2013-05-05 21:49:21 UTC",
+                                                "2013-05-05 21:49:34 UTC", "2013-05-06 01:04:34 UTC",
+                                                "2013-05-25 03:48:41 UTC", "2013-05-25 04:08:07 UTC",
+                                                "2016-07-12 14:59:25 UTC", "2016-07-12 16:02:30 UTC",
+                                                "2016-07-12 16:06:01 UTC", "2016-07-15 19:55:39 UTC",
+                                                "2017-05-23 12:32:39 UTC", "2016-07-12 15:59:59 UTC",
+                                                "2016-07-15 20:07:47 UTC", "2016-07-27 20:12:08 UTC",
+                                                "2016-07-28 06:27:52 UTC", "2013-05-25 03:25:06 UTC",
+                                                "2013-05-25 06:06:53 UTC", "2013-05-25 06:22:23 UTC",
+                                                "2013-06-01 06:50:26 UTC", "2016-07-12 16:01:01 UTC",
+                                                "2016-07-12 16:02:02 UTC", "2013-04-21 23:52:09 UTC",
+                                                "2016-07-12 15:59:25 UTC", "2016-07-12 16:03:59 UTC")))),
+        artifact.type = I(c(as.list(rep("Feature", 6)), as.list(rep("IssueEvent", 24)))),
+        hash = I(c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "1143db502761379c2bfcecc2007fc34282e7ee61",
+                   "5a5ec9675e98187e1e92561e1888aa6f04faa338", "3a0ed78458b3976243db6829f63eba3eead26774",
+                   "0a1a5c523d835459c42f33e863623138555e2526", "0a1a5c523d835459c42f33e863623138555e2526",
+                   as.list(rep(NA, 24)))),
+        file = I(c("test.c", "test3.c", "test.c", "test2.c", "test2.c", "test2.c", as.list(rep(NA, 24)))),
+        artifact = I(c("A", "Base_Feature", "A", "Base_Feature", "Base_Feature", "foo", as.list(rep(NA, 24)))),
         weight = c(rep(1, 30)),
         type = c(rep("Bipartite", 30)),
         relation = c(rep("cochange", 6), rep("issue", 24)),
-        issue.id = c(NA,                          NA,                          NA,
-                     NA,                          NA,                          NA,
-                     "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                     "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                     "<issue-github-2>",          "<issue-jira-ZEPPELIN-332>", "<issue-github-1>",
-                     "<issue-jira-ZEPPELIN-332>", "<issue-github-6>",          "<issue-github-3>",
-                     "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>",
-                     "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                     "<issue-jira-ZEPPELIN-328>", "<issue-github-1>",          "<issue-github-4>",
-                     "<issue-jira-ZEPPELIN-328>", "<issue-github-1>",          "<issue-github-6>"),
-        event.name = c(rep(NA, 6), rep("commented", 24))
+        issue.id = I(c(as.list(rep(NA, 6)),
+                       "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                       "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                       "<issue-github-2>",          "<issue-jira-ZEPPELIN-332>", "<issue-github-1>",
+                       "<issue-jira-ZEPPELIN-332>", "<issue-github-6>",          "<issue-github-3>",
+                       "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>",
+                       "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                       "<issue-jira-ZEPPELIN-328>", "<issue-github-1>",          "<issue-github-4>",
+                       "<issue-jira-ZEPPELIN-328>", "<issue-github-1>",          "<issue-github-6>")),
+        event.name = I(c(as.list(rep(NA, 6)), rep("commented", 24)))
     )
+
+    ## Remove the 'AsIs' class from the edge attributes that have been inserted via `I(...)`
+    edges[["date"]] = unclass(edges[["date"]])
+    edges[["artifact.type"]] = unclass(edges[["artifact.type"]])
+    edges[["hash"]] = unclass(edges[["hash"]])
+    edges[["file"]] = unclass(edges[["file"]])
+    edges[["artifact"]] = unclass(edges[["artifact"]])
+    edges[["issue.id"]] = unclass(edges[["issue.id"]])
+    edges[["event.name"]] = unclass(edges[["event.name"]])
 
     net.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
 
@@ -463,38 +501,47 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
                   "<thread-42#2>", "<thread-13#8>", "<thread-42#4>", "<thread-42#5>", "<thread-42#6>",
                   "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>",
                   "<thread-42#7>", "<thread-13#8>", "<thread-13#9>", "<thread-13#9>", "<thread-13#3>"),
-           date = get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:06:10", "2016-07-12 16:00:45",
-                                         "2016-07-12 16:05:41", "2016-07-12 16:06:32", "2016-07-12 16:06:32",
-                                         "2004-10-09 18:38:13", "2005-02-09 18:49:49", "2016-07-12 15:58:40",
-                                         "2010-07-12 11:05:35", "2010-07-12 12:05:34", "2010-07-12 12:05:40",
-                                         "2010-07-12 12:05:41", "2010-07-12 12:05:42", "2010-07-12 12:05:43",
-                                         "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2010-07-12 12:05:46",
-                                         "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:04:40",
-                                         "2010-07-12 10:05:36")),
-           artifact.type = c(rep("Feature", 6), rep("Mail", 16)),
-           hash = c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "1143db502761379c2bfcecc2007fc34282e7ee61",
-                    "5a5ec9675e98187e1e92561e1888aa6f04faa338", "3a0ed78458b3976243db6829f63eba3eead26774",
-                    "0a1a5c523d835459c42f33e863623138555e2526", "0a1a5c523d835459c42f33e863623138555e2526",
-                    rep(NA, 16)),
-           file = c("test.c", "test3.c", "test.c", "test2.c", "test2.c", "test2.c", rep(NA, 16)),
-           artifact = c("A", "Base_Feature", "A", "Base_Feature", "Base_Feature", "foo", rep(NA, 16)),
+           date = I(as.list(get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:06:10", "2016-07-12 16:00:45",
+                                                   "2016-07-12 16:05:41", "2016-07-12 16:06:32", "2016-07-12 16:06:32",
+                                                   "2004-10-09 18:38:13", "2005-02-09 18:49:49", "2016-07-12 15:58:40",
+                                                   "2010-07-12 11:05:35", "2010-07-12 12:05:34", "2010-07-12 12:05:40",
+                                                   "2010-07-12 12:05:41", "2010-07-12 12:05:42", "2010-07-12 12:05:43",
+                                                   "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2010-07-12 12:05:46",
+                                                   "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:04:40",
+                                                   "2010-07-12 10:05:36")))),
+           artifact.type = I(c(as.list(rep("Feature", 6)), as.list(rep("Mail", 16)))),
+           hash = I(c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "1143db502761379c2bfcecc2007fc34282e7ee61",
+                      "5a5ec9675e98187e1e92561e1888aa6f04faa338", "3a0ed78458b3976243db6829f63eba3eead26774",
+                      "0a1a5c523d835459c42f33e863623138555e2526", "0a1a5c523d835459c42f33e863623138555e2526",
+                      as.list(rep(NA, 16)))),
+           file = I(c("test.c", "test3.c", "test.c", "test2.c", "test2.c", "test2.c", as.list(rep(NA, 16)))),
+           artifact = I(c("A", "Base_Feature", "A", "Base_Feature", "Base_Feature", "foo", as.list(rep(NA, 16)))),
            weight = rep(1,22),
            type = rep("Bipartite", 22),
            relation = c(rep("cochange", 6), rep("mail", 16)),
-           message.id = c(rep(NA, 6), "<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>",
-                          "<1107974989.17910.6.camel@jmcmullan>", "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
-                          "<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>", "<dfhglkjdgjkhnwrd@mail.gmail.com>",
-                          "<hans1@mail.gmail.com>", "<hans2@mail.gmail.com>", "<hans3@mail.gmail.com>",
-                          "<hans4@mail.gmail.com>", "<hans5@mail.gmail.com>", "<hans6@mail.gmail.com>",
-                          "<hans7@mail.gmail.com>", "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
-                          "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>",
-                          "<65a1sf31sagd684dfv31@mail.gmail.com>", "<asddghdswqeasdasd@mail.gmail.com>"
-                          ),
-           thread = c(rep(NA, 6), "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>",
-                      "<thread-42#5>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>",
-                      "<thread-42#6>", "<thread-42#6>", "<thread-42#7>", "<thread-13#8>", "<thread-13#9>",
-                      "<thread-13#9>", "<thread-13#3>")
+           message.id = I(c(as.list(rep(NA, 6)), "<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>",
+                            "<1107974989.17910.6.camel@jmcmullan>", "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
+                            "<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>", "<dfhglkjdgjkhnwrd@mail.gmail.com>",
+                            "<hans1@mail.gmail.com>", "<hans2@mail.gmail.com>", "<hans3@mail.gmail.com>",
+                            "<hans4@mail.gmail.com>", "<hans5@mail.gmail.com>", "<hans6@mail.gmail.com>",
+                            "<hans7@mail.gmail.com>", "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
+                            "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>",
+                            "<65a1sf31sagd684dfv31@mail.gmail.com>", "<asddghdswqeasdasd@mail.gmail.com>"
+                            )),
+           thread = I(c(as.list(rep(NA, 6)), "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>",
+                        "<thread-42#5>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>",
+                        "<thread-42#6>", "<thread-42#6>", "<thread-42#7>", "<thread-13#8>", "<thread-13#9>",
+                        "<thread-13#9>", "<thread-13#3>"))
     )
+
+    ## Remove the 'AsIs' class from the edge attributes that have been inserted via `I(...)`
+    edges[["date"]] = unclass(edges[["date"]])
+    edges[["artifact.type"]] = unclass(edges[["artifact.type"]])
+    edges[["hash"]] = unclass(edges[["hash"]])
+    edges[["file"]] = unclass(edges[["file"]])
+    edges[["artifact"]] = unclass(edges[["artifact"]])
+    edges[["message.id"]] = unclass(edges[["message.id"]])
+    edges[["thread"]] = unclass(edges[["thread"]])
 
     net.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
 
@@ -557,47 +604,55 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
                   "<issue-github-6>", "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>",
                   "<thread-42#5>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>",
                   "<thread-42#6>", "<thread-42#7>", "<thread-13#8>", "<thread-13#9>", "<thread-13#9>", "<thread-13#3>"),
-           date = get.date.from.string(c("2013-05-05 21:46:30", "2013-05-05 21:49:21", "2013-05-05 21:49:34",
-                                         "2013-05-06 01:04:34", "2013-05-25 03:48:41", "2013-05-25 04:08:07",
-                                         "2016-07-12 14:59:25", "2016-07-12 16:02:30", "2016-07-12 16:06:01",
-                                         "2016-07-15 19:55:39", "2017-05-23 12:32:39", "2016-07-12 15:59:59",
-                                         "2016-07-15 20:07:47", "2016-07-27 20:12:08", "2016-07-28 06:27:52",
-                                         "2013-05-25 03:25:06", "2013-05-25 06:06:53", "2013-05-25 06:22:23",
-                                         "2013-06-01 06:50:26", "2016-07-12 16:01:01", "2016-07-12 16:02:02",
-                                         "2013-04-21 23:52:09", "2016-07-12 15:59:25", "2016-07-12 16:03:59",
-                                         "2004-10-09 18:38:13", "2005-02-09 18:49:49", "2016-07-12 15:58:40",
-                                         "2010-07-12 11:05:35", "2010-07-12 12:05:34", "2010-07-12 12:05:40",
-                                         "2010-07-12 12:05:41", "2010-07-12 12:05:42", "2010-07-12 12:05:43",
-                                         "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2010-07-12 12:05:46",
-                                         "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:04:40",
-                                         "2010-07-12 10:05:36")),
-           artifact.type = c(rep("IssueEvent", 24), rep("Mail", 16)),
-           issue.id = c("<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                        "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                        "<issue-github-2>", "<issue-jira-ZEPPELIN-332>", "<issue-github-1>",
-                        "<issue-jira-ZEPPELIN-332>", "<issue-github-6>", "<issue-github-3>",
-                        "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>",
-                        "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
-                        "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-4>",
-                        "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-6>", rep(NA, 16)),
-           event.name = c(rep("commented", 24), rep(NA, 16)),
+           date = I(as.list(get.date.from.string(c("2013-05-05 21:46:30", "2013-05-05 21:49:21", "2013-05-05 21:49:34",
+                                                   "2013-05-06 01:04:34", "2013-05-25 03:48:41", "2013-05-25 04:08:07",
+                                                   "2016-07-12 14:59:25", "2016-07-12 16:02:30", "2016-07-12 16:06:01",
+                                                   "2016-07-15 19:55:39", "2017-05-23 12:32:39", "2016-07-12 15:59:59",
+                                                   "2016-07-15 20:07:47", "2016-07-27 20:12:08", "2016-07-28 06:27:52",
+                                                   "2013-05-25 03:25:06", "2013-05-25 06:06:53", "2013-05-25 06:22:23",
+                                                   "2013-06-01 06:50:26", "2016-07-12 16:01:01", "2016-07-12 16:02:02",
+                                                   "2013-04-21 23:52:09", "2016-07-12 15:59:25", "2016-07-12 16:03:59",
+                                                   "2004-10-09 18:38:13", "2005-02-09 18:49:49", "2016-07-12 15:58:40",
+                                                   "2010-07-12 11:05:35", "2010-07-12 12:05:34", "2010-07-12 12:05:40",
+                                                   "2010-07-12 12:05:41", "2010-07-12 12:05:42", "2010-07-12 12:05:43",
+                                                   "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2010-07-12 12:05:46",
+                                                   "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:04:40",
+                                                   "2010-07-12 10:05:36")))),
+           artifact.type = I(c(as.list(rep("IssueEvent", 24)), as.list(rep("Mail", 16)))),
+           issue.id = I(c("<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                          "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                          "<issue-github-2>", "<issue-jira-ZEPPELIN-332>", "<issue-github-1>",
+                          "<issue-jira-ZEPPELIN-332>", "<issue-github-6>", "<issue-github-3>",
+                          "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-332>",
+                          "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+                          "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-4>",
+                          "<issue-jira-ZEPPELIN-328>", "<issue-github-1>", "<issue-github-6>", as.list(rep(NA, 16)))),
+           event.name = I(c(rep("commented", 24), as.list(rep(NA, 16)))),
            weight = rep(1, 40),
            type = rep("Bipartite", 40),
            relation = c(rep("issue", 24), rep("mail", 16)),
-           message.id = c(rep(NA, 24),
-                          "<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>", "<1107974989.17910.6.camel@jmcmullan>",
-                          "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
-                          "<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>", "<dfhglkjdgjkhnwrd@mail.gmail.com>",
-                          "<hans1@mail.gmail.com>", "<hans2@mail.gmail.com>", "<hans3@mail.gmail.com>",
-                          "<hans4@mail.gmail.com>", "<hans5@mail.gmail.com>", "<hans6@mail.gmail.com>",
-                          "<hans7@mail.gmail.com>", "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
-                          "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>",
-                          "<65a1sf31sagd684dfv31@mail.gmail.com>", "<asddghdswqeasdasd@mail.gmail.com>"
-                          ),
-           thread = c(rep(NA, 24), "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>", "<thread-42#5>",
-                      "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>",
-                      "<thread-42#7>", "<thread-13#8>", "<thread-13#9>", "<thread-13#9>", "<thread-13#3>")
+           message.id = I(c(as.list(rep(NA, 24)),
+                            "<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>", "<1107974989.17910.6.camel@jmcmullan>",
+                            "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
+                            "<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>", "<dfhglkjdgjkhnwrd@mail.gmail.com>",
+                            "<hans1@mail.gmail.com>", "<hans2@mail.gmail.com>", "<hans3@mail.gmail.com>",
+                            "<hans4@mail.gmail.com>", "<hans5@mail.gmail.com>", "<hans6@mail.gmail.com>",
+                            "<hans7@mail.gmail.com>", "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
+                            "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>",
+                            "<65a1sf31sagd684dfv31@mail.gmail.com>", "<asddghdswqeasdasd@mail.gmail.com>"
+                            )),
+           thread = I(c(as.list(rep(NA, 24)), "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>", "<thread-42#5>",
+                        "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>",
+                        "<thread-42#7>", "<thread-13#8>", "<thread-13#9>", "<thread-13#9>", "<thread-13#3>"))
     )
+
+    ## Remove the 'AsIs' class from the edge attributes that have been inserted via `I(...)`
+    edges[["date"]] = unclass(edges[["date"]])
+    edges[["artifact.type"]] = unclass(edges[["artifact.type"]])
+    edges[["issue.id"]] = unclass(edges[["issue.id"]])
+    edges[["event.name"]] = unclass(edges[["event.name"]])
+    edges[["message.id"]] = unclass(edges[["message.id"]])
+    edges[["thread"]] = unclass(edges[["thread"]])
 
     net.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
 
@@ -670,33 +725,33 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
                   "<thread-13#8>", "<thread-42#4>", "<thread-42#5>", "<thread-42#6>", "<thread-42#6>",
                   "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#7>",
                   "<thread-13#8>", "<thread-13#9>", "<thread-13#9>", "<thread-13#3>"),
-           date = get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:06:10", "2016-07-12 16:00:45",
-                                         "2016-07-12 16:05:41", "2016-07-12 16:06:32", "2016-07-12 16:06:32",
-                                         "2013-05-05 21:46:30", "2013-05-05 21:49:21", "2013-05-05 21:49:34",
-                                         "2013-05-06 01:04:34", "2013-05-25 03:48:41", "2013-05-25 04:08:07",
-                                         "2016-07-12 14:59:25", "2016-07-12 16:02:30", "2016-07-12 16:06:01",
-                                         "2016-07-15 19:55:39", "2017-05-23 12:32:39", "2016-07-12 15:59:59",
-                                         "2016-07-15 20:07:47", "2016-07-27 20:12:08", "2016-07-28 06:27:52",
-                                         "2013-05-25 03:25:06", "2013-05-25 06:06:53", "2013-05-25 06:22:23",
-                                         "2013-06-01 06:50:26", "2016-07-12 16:01:01", "2016-07-12 16:02:02",
-                                         "2013-04-21 23:52:09", "2016-07-12 15:59:25", "2016-07-12 16:03:59",
-                                         "2004-10-09 18:38:13", "2005-02-09 18:49:49", "2016-07-12 15:58:40",
-                                         "2010-07-12 11:05:35", "2010-07-12 12:05:34", "2010-07-12 12:05:40",
-                                         "2010-07-12 12:05:41", "2010-07-12 12:05:42", "2010-07-12 12:05:43",
-                                         "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2010-07-12 12:05:46",
-                                         "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:04:40",
-                                         "2010-07-12 10:05:36")),
-           artifact.type = c(rep("Feature", 6), rep("IssueEvent", 24), rep("Mail", 16)),
-           hash = c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "1143db502761379c2bfcecc2007fc34282e7ee61",
-                    "5a5ec9675e98187e1e92561e1888aa6f04faa338", "3a0ed78458b3976243db6829f63eba3eead26774",
-                    "0a1a5c523d835459c42f33e863623138555e2526", "0a1a5c523d835459c42f33e863623138555e2526",
-                    rep(NA, 40)),
-           file = c("test.c", "test3.c", "test.c", "test2.c", "test2.c", "test2.c", rep(NA, 40)),
-           artifact = c("A", "Base_Feature", "A", "Base_Feature", "Base_Feature", "foo", rep(NA, 40)),
+           date = I(as.list(get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:06:10", "2016-07-12 16:00:45",
+                                                   "2016-07-12 16:05:41", "2016-07-12 16:06:32", "2016-07-12 16:06:32",
+                                                   "2013-05-05 21:46:30", "2013-05-05 21:49:21", "2013-05-05 21:49:34",
+                                                   "2013-05-06 01:04:34", "2013-05-25 03:48:41", "2013-05-25 04:08:07",
+                                                   "2016-07-12 14:59:25", "2016-07-12 16:02:30", "2016-07-12 16:06:01",
+                                                   "2016-07-15 19:55:39", "2017-05-23 12:32:39", "2016-07-12 15:59:59",
+                                                   "2016-07-15 20:07:47", "2016-07-27 20:12:08", "2016-07-28 06:27:52",
+                                                   "2013-05-25 03:25:06", "2013-05-25 06:06:53", "2013-05-25 06:22:23",
+                                                   "2013-06-01 06:50:26", "2016-07-12 16:01:01", "2016-07-12 16:02:02",
+                                                   "2013-04-21 23:52:09", "2016-07-12 15:59:25", "2016-07-12 16:03:59",
+                                                   "2004-10-09 18:38:13", "2005-02-09 18:49:49", "2016-07-12 15:58:40",
+                                                   "2010-07-12 11:05:35", "2010-07-12 12:05:34", "2010-07-12 12:05:40",
+                                                   "2010-07-12 12:05:41", "2010-07-12 12:05:42", "2010-07-12 12:05:43",
+                                                   "2010-07-12 12:05:44", "2010-07-12 12:05:45", "2010-07-12 12:05:46",
+                                                   "2016-07-12 15:58:50", "2016-07-12 16:05:37", "2016-07-12 16:04:40",
+                                                   "2010-07-12 10:05:36")))),
+           artifact.type = I(c(as.list(rep("Feature", 6)), as.list(rep("IssueEvent", 24)), as.list(rep("Mail", 16)))),
+           hash = I(c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "1143db502761379c2bfcecc2007fc34282e7ee61",
+                      "5a5ec9675e98187e1e92561e1888aa6f04faa338", "3a0ed78458b3976243db6829f63eba3eead26774",
+                      "0a1a5c523d835459c42f33e863623138555e2526", "0a1a5c523d835459c42f33e863623138555e2526",
+                      as.list(rep(NA, 40)))),
+           file = I(c("test.c", "test3.c", "test.c", "test2.c", "test2.c", "test2.c", as.list(rep(NA, 40)))),
+           artifact = I(c("A", "Base_Feature", "A", "Base_Feature", "Base_Feature", "foo", as.list(rep(NA, 40)))),
            weight = rep(1, 46),
            type = rep("Bipartite", 46),
            relation = c(rep("cochange", 6), rep("issue", 24), rep("mail", 16)),
-           issue.id = c(rep(NA, 6), "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
+           issue.id = I(c(as.list(rep(NA, 6)), "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
                         "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
                         "<issue-jira-ZEPPELIN-328>", "<issue-github-2>", "<issue-jira-ZEPPELIN-332>",
                         "<issue-github-1>", "<issue-jira-ZEPPELIN-332>", "<issue-github-6>",
@@ -704,21 +759,32 @@ test_that("Construction of the multi-artifact bipartite network with artifact re
                         "<issue-jira-ZEPPELIN-332>", "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>",
                         "<issue-jira-ZEPPELIN-328>", "<issue-jira-ZEPPELIN-328>", "<issue-github-1>",
                         "<issue-github-4>", "<issue-jira-ZEPPELIN-328>", "<issue-github-1>",
-                        "<issue-github-6>", rep(NA, 16)),
-           event.name = c(rep(NA, 6), rep("commented", 24), rep(NA, 16)),
-           message.id = c(rep(NA, 30), "<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>",
-                          "<1107974989.17910.6.camel@jmcmullan>", "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
-                          "<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>", "<dfhglkjdgjkhnwrd@mail.gmail.com>",
-                          "<hans1@mail.gmail.com>", "<hans2@mail.gmail.com>", "<hans3@mail.gmail.com>",
-                          "<hans4@mail.gmail.com>", "<hans5@mail.gmail.com>", "<hans6@mail.gmail.com>",
-                          "<hans7@mail.gmail.com>", "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
-                          "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>",
-                          "<65a1sf31sagd684dfv31@mail.gmail.com>", "<asddghdswqeasdasd@mail.gmail.com>"),
-           thread = c(rep(NA, 30), "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>",
+                        "<issue-github-6>", as.list(rep(NA, 16)))),
+           event.name = I(c(as.list(rep(NA, 6)), rep("commented", 24), as.list(rep(NA, 16)))),
+           message.id = I(c(as.list(rep(NA, 30)), "<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>",
+                            "<1107974989.17910.6.camel@jmcmullan>", "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
+                            "<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>", "<dfhglkjdgjkhnwrd@mail.gmail.com>",
+                            "<hans1@mail.gmail.com>", "<hans2@mail.gmail.com>", "<hans3@mail.gmail.com>",
+                            "<hans4@mail.gmail.com>", "<hans5@mail.gmail.com>", "<hans6@mail.gmail.com>",
+                            "<hans7@mail.gmail.com>", "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>",
+                             "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>",
+                            "<65a1sf31sagd684dfv31@mail.gmail.com>", "<asddghdswqeasdasd@mail.gmail.com>")),
+           thread = I(c(as.list(rep(NA, 30)), "<thread-13#1>", "<thread-42#2>", "<thread-13#8>", "<thread-42#4>",
                       "<thread-42#5>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>", "<thread-42#6>",
                       "<thread-42#6>", "<thread-42#6>", "<thread-42#7>", "<thread-13#8>", "<thread-13#9>",
-                      "<thread-13#9>", "<thread-13#3>")
+                      "<thread-13#9>", "<thread-13#3>"))
     )
+
+    ## Remove the 'AsIs' class from the edge attributes that have been inserted via `I(...)`
+    edges[["date"]] = unclass(edges[["date"]])
+    edges[["artifact.type"]] = unclass(edges[["artifact.type"]])
+    edges[["hash"]] = unclass(edges[["hash"]])
+    edges[["file"]] = unclass(edges[["file"]])
+    edges[["artifact"]] = unclass(edges[["artifact"]])
+    edges[["issue.id"]] = unclass(edges[["issue.id"]])
+    edges[["event.name"]] = unclass(edges[["event.name"]])
+    edges[["message.id"]] = unclass(edges[["message.id"]])
+    edges[["thread"]] = unclass(edges[["thread"]])
 
     net.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
 

--- a/tests/test-networks-multi.R
+++ b/tests/test-networks-multi.R
@@ -82,16 +82,21 @@ test_that("Construction of the multi network for the feature artifact with autho
                            "0a1a5c523d835459c42f33e863623138555e2526"),
                   file = c("test.c", "test.c", "test2.c", "test3.c", "test2.c", "test2.c", "test3.c", "test2.c",
                            "test2.c", "test.c", "test.c", "test2.c", "test3.c", "test2.c", "test2.c"),
-                  artifact = c("A", "A", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature",
-                               "Base_Feature", NA, "A", "A", "Base_Feature", "Base_Feature", "Base_Feature",
-                               "foo"),
+                  artifact = I(list("A", "A", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature", "Base_Feature",
+                                  "Base_Feature", NA, "A", "A", "Base_Feature", "Base_Feature", "Base_Feature",
+                                  "foo")),
                   weight = 1,
                   type = c(rep(TYPE.EDGES.INTRA, 9), rep(TYPE.EDGES.INTER, 6)),
                   relation = "cochange",
-                  author.name = c(NA, NA, NA, NA, NA, NA, NA, NA, "Thomas", NA, NA, NA, NA, NA, NA)
+                  author.name = I(list(NA, NA, NA, NA, NA, NA, NA, NA, "Thomas", NA, NA, NA, NA, NA, NA))
               )
 
+              ## remove the 'AsIs' class from the edge attributes that have been inserted via `I(...)`
+              edges[["artifact"]] = unclass(edges[["artifact"]])
+              edges[["author.name"]] = unclass(edges[["author.name"]])
+
               network.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
+              network.expected = convert.edge.attributes.to.list(network.expected)
 
               assert.networks.equal(network.expected, network.built)
           })

--- a/tests/test-networks.R
+++ b/tests/test-networks.R
@@ -632,7 +632,7 @@ test_that("Construction of networks from empty edge list (with vertices)", {
     ##
 
     net.constructed = construct.network.from.edge.list(vertices, edge.list, net.conf)
-    net.expected = igraph::graph.empty(n = 0, directed = directed) +
+    net.expected = igraph::make_empty_graph(n = 0, directed = directed) +
         igraph::vertices(vertices.as.sequence) +
         igraph::edges(edge.list.as.sequence, weight = 1)
 

--- a/tests/test-networks.R
+++ b/tests/test-networks.R
@@ -135,34 +135,34 @@ test_that("Simplify author-network with relation = c('cochange', 'mail') using b
                                   "Björn", "Olaf"), # mail
                       comb.2. = c("Olaf", "Karl", "Thomas", "Thomas", # cochange
                                   "Olaf", "Thomas")) # mail
-    data$date = list(get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45")),
-                     get.date.from.string(c("2016-07-12 16:05:41", "2016-07-12 16:06:10")),
-                     get.date.from.string(c("2016-07-12 16:05:41", "2016-07-12 16:06:32")),
-                     get.date.from.string(c("2016-07-12 16:06:10", "2016-07-12 16:06:32")), # cochange
-                     get.date.from.string(c("2016-07-12 15:58:40", "2016-07-12 15:58:50")),
-                     get.date.from.string(c("2016-07-12 16:04:40", "2016-07-12 16:05:37"))) # mail
-    data$artifact.type = list(c("Feature", "Feature"), c("Feature", "Feature"),
-                              c("Feature", "Feature"), c("Feature", "Feature"), # cochange
-                              c("Mail", "Mail"), c("Mail", "Mail")) # mail
-    data$hash = list(c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338"),
-                     c("3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61"),
-                     c("3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526"),
-                     c("1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526"),
-                     as.character(c(NA, NA)), as.character(c(NA, NA)))
-    data$file = list(c("test.c", "test.c"), c("test2.c", "test3.c"), c("test2.c", "test2.c"), c("test3.c", "test2.c"),
-                     as.character(c(NA, NA)), as.character(c(NA, NA)))
-    data$artifact = list(c("A", "A"), c("Base_Feature", "Base_Feature"), c("Base_Feature", "Base_Feature"), 
-                         c("Base_Feature", "Base_Feature"), as.character(c(NA, NA)), as.character(c(NA, NA)))
+    data$date = list(as.list(get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45"))),
+                     as.list(get.date.from.string(c("2016-07-12 16:05:41", "2016-07-12 16:06:10"))),
+                     as.list(get.date.from.string(c("2016-07-12 16:05:41", "2016-07-12 16:06:32"))),
+                     as.list(get.date.from.string(c("2016-07-12 16:06:10", "2016-07-12 16:06:32"))), # cochange
+                     as.list(get.date.from.string(c("2016-07-12 15:58:40", "2016-07-12 15:58:50"))),
+                     as.list(get.date.from.string(c("2016-07-12 16:04:40", "2016-07-12 16:05:37")))) # mail
+    data$artifact.type = list(list("Feature", "Feature"), list("Feature", "Feature"),
+                              list("Feature", "Feature"), list("Feature", "Feature"), # cochange
+                              list("Mail", "Mail"), list("Mail", "Mail")) # mail
+    data$hash = list(list("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338"),
+                     list("3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61"),
+                     list("3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526"),
+                     list("1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526"),
+                     as.list(rep(NA, 2)), as.list(rep(NA, 2)))
+    data$file = list(list("test.c", "test.c"), list("test2.c", "test3.c"), list("test2.c", "test2.c"), list("test3.c", "test2.c"),
+                     as.list(rep(NA, 2)), as.list(rep(NA, 2)))
+    data$artifact = list(list("A", "A"), list("Base_Feature", "Base_Feature"), list("Base_Feature", "Base_Feature"),
+                         list("Base_Feature", "Base_Feature"), as.list(rep(NA, 2)), as.list(rep(NA, 2)))
     data$weight = rep(2, 6)
     data$type = rep(TYPE.EDGES.INTRA, 6)
     data$relation = c(rep("cochange", 4), rep("mail", 2))
-    data$message.id = list(as.character(c(NA, NA)), as.character(c(NA, NA)), as.character(c(NA, NA)), as.character(c(NA, NA)),
-                           c("<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
-                             "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>"),
-                           c("<65a1sf31sagd684dfv31@mail.gmail.com>",
-                             "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>"))
-    data$thread = list(as.character(c(NA, NA)), as.character(c(NA, NA)), as.character(c(NA, NA)), as.character(c(NA, NA)),
-                       c("<thread-13#8>", "<thread-13#8>"), c("<thread-13#9>", "<thread-13#9>"))
+    data$message.id = list(as.list(rep(NA, 2)), as.list(rep(NA, 2)), as.list(rep(NA, 2)), as.list(rep(NA, 2)),
+                           list("<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
+                                "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>"),
+                           list("<65a1sf31sagd684dfv31@mail.gmail.com>",
+                                "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>"))
+    data$thread = list(as.list(rep(NA, 2)), as.list(rep(NA, 2)), as.list(rep(NA, 2)), as.list(rep(NA, 2)),
+                       list("<thread-13#8>", "<thread-13#8>"), list("<thread-13#9>", "<thread-13#9>"))
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(data, vertices = authors,
@@ -179,37 +179,38 @@ test_that("Simplify author-network with relation = c('cochange', 'mail') using b
     data = data.frame(comb.1. = c("Björn", "Olaf", "Olaf", "Karl"),
                       comb.2. = c("Olaf", "Karl", "Thomas", "Thomas"))
 
-    data$date = list(get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45",   # cochange
-                                            "2016-07-12 15:58:40", "2016-07-12 15:58:50")), # mail
-                     get.date.from.string(c("2016-07-12 16:05:41", "2016-07-12 16:06:10")), # cochange
-                     get.date.from.string(c("2016-07-12 16:05:41", "2016-07-12 16:06:32",   # cochange
-                                            "2016-07-12 16:04:40", "2016-07-12 16:05:37")), # mail
-                     get.date.from.string(c("2016-07-12 16:06:10", "2016-07-12 16:06:32"))) # cochange
-    data$artifact.type = list(c("Feature", "Feature", "Mail", "Mail"),
-                              c("Feature", "Feature"),
-                              c("Feature", "Feature", "Mail", "Mail"),
-                              c("Feature", "Feature"))
-    data$hash = list(as.character(c("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338", NA, NA)),
-                     c("3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61"),
-                     as.character(c("3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526", NA, NA)),
-                     c("1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526"))
-    data$file = list(as.character(c("test.c", "test.c", NA, NA)), c("test2.c", "test3.c"),
-                     as.character(c("test2.c", "test2.c", NA, NA)), c("test3.c", "test2.c"))
-    data$artifact = list(as.character(c("A", "A", NA, NA)), c("Base_Feature", "Base_Feature"),
-                         as.character(c("Base_Feature", "Base_Feature", NA, NA)), c("Base_Feature", "Base_Feature"))
+    data$date = list(as.list(get.date.from.string(c("2016-07-12 15:58:59", "2016-07-12 16:00:45",    # cochange
+                                                    "2016-07-12 15:58:40", "2016-07-12 15:58:50"))), # mail
+                     as.list(get.date.from.string(c("2016-07-12 16:05:41", "2016-07-12 16:06:10"))), # cochange
+                     as.list(get.date.from.string(c("2016-07-12 16:05:41", "2016-07-12 16:06:32",    # cochange
+                                                    "2016-07-12 16:04:40", "2016-07-12 16:05:37"))), # mail
+                     as.list(get.date.from.string(c("2016-07-12 16:06:10", "2016-07-12 16:06:32")))) # cochange
+    data$artifact.type = list(list("Feature", "Feature", "Mail", "Mail"),
+                              list("Feature", "Feature"),
+                              list("Feature", "Feature", "Mail", "Mail"),
+                              list("Feature", "Feature"))
+
+    data$hash = list(list("72c8dd25d3dd6d18f46e2b26a5f5b1e2e8dc28d0", "5a5ec9675e98187e1e92561e1888aa6f04faa338", NA, NA),
+                     list("3a0ed78458b3976243db6829f63eba3eead26774", "1143db502761379c2bfcecc2007fc34282e7ee61"),
+                     list("3a0ed78458b3976243db6829f63eba3eead26774", "0a1a5c523d835459c42f33e863623138555e2526", NA, NA),
+                     list("1143db502761379c2bfcecc2007fc34282e7ee61", "0a1a5c523d835459c42f33e863623138555e2526"))
+    data$file = list(list("test.c", "test.c", NA, NA), list("test2.c", "test3.c"),
+                     list("test2.c", "test2.c", NA, NA), list("test3.c", "test2.c"))
+    data$artifact = list(list("A", "A", NA, NA), list("Base_Feature", "Base_Feature"),
+                         list("Base_Feature", "Base_Feature", NA, NA), list("Base_Feature", "Base_Feature"))
     data$weight = c(4, 2, 4, 2)
     data$type = rep(TYPE.EDGES.INTRA, 4)
     data$relation = list(c("cochange", "mail"), c("cochange"), c("cochange", "mail"), c("cochange"))
-    data$message.id = list(as.character(c(NA, NA, "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
-                                          "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>")),
-                           as.character(c(NA, NA)),
-                           as.character(c(NA, NA, "<65a1sf31sagd684dfv31@mail.gmail.com>",
-                                          "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>")),
-                           as.character(c(NA, NA)))
-    data$thread = list(as.character(c(NA, NA, "<thread-13#8>", "<thread-13#8>")),
-                       as.character(c(NA, NA)),
-                       as.character(c(NA, NA, "<thread-13#9>", "<thread-13#9>")),
-                       as.character(c(NA, NA)))
+    data$message.id = list(list(NA, NA, "<4cbaa9ef0802201124v37f1eec8g89a412dfbfc8383a@mail.gmail.com>",
+                                        "<6784529b0802032245r5164f984l342f0f0dc94aa420@mail.gmail.com>"),
+                           list(NA, NA),
+                           list(NA, NA, "<65a1sf31sagd684dfv31@mail.gmail.com>",
+                                        "<9b06e8d20801220234h659c18a3g95c12ac38248c7e0@mail.gmail.com>"),
+                           list(NA, NA))
+    data$thread = list(list(NA, NA, "<thread-13#8>", "<thread-13#8>"),
+                       list(NA, NA),
+                       list(NA, NA, "<thread-13#9>", "<thread-13#9>"),
+                       list(NA, NA))
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(data, vertices = authors,
@@ -354,6 +355,7 @@ test_that("Remove duplicate edges", {
 
     ## build expected network
     network.expected = igraph::graph_from_data_frame(edges, directed = FALSE, vertices = vertices)
+    network.expected = convert.edge.attributes.to.list(network.expected)
 
     ## build network with unique edges
     network = network.builder$get.author.network()

--- a/tests/test-networks.R
+++ b/tests/test-networks.R
@@ -992,6 +992,54 @@ test_that("Addition of edge attributes with data", {
 
 })
 
+
+patrick::with_parameters_test_that("Convert edge attributes to list", {
+
+    ## configure edge attributes
+    edge.attributes = c("date", "message.id", "thread", "weight", "type", "relation")
+    attribute.defaults = list(get.date.from.string("2020-01-01 00:00:00"), "abc", "def", 1, TYPE.EDGES.INTRA, "mail")
+
+    ## construct network
+    network =
+        igraph::make_empty_graph(n = 0, directed = FALSE) +
+        igraph::vertices("A", "B", "C", type = TYPE.AUTHOR, kind = TYPE.AUTHOR) +
+        igraph::edges("A", "B", "B", "C", "C", "A")
+
+    ## assign edge attributes
+    for (i in seq_along(edge.attributes)) {
+        network = igraph::set_edge_attr(network, edge.attributes[i], value = attribute.defaults[[i]])
+    }
+
+    ## convert specified edge attributes to list
+    if (is.null(remain.as.is)) {
+        network.listified = convert.edge.attributes.to.list(network)
+
+        ## set 'remain.as.is' to the default of 'convert.edge.attributes.to.list'
+        ## for later use in the validation process
+        remain.as.is = names(EDGE.ATTR.HANDLING)
+    } else {
+        network.listified = convert.edge.attributes.to.list(network, remain.as.is = remain.as.is)
+    }
+
+    ## check edge attributes
+    for (attr in igraph::edge_attr_names(network)) {
+        conversion.function = ifelse(attr %in% remain.as.is, identity, as.list)
+        expect_equal(
+            conversion.function(igraph::edge_attr(network, attr)),
+            igraph::edge_attr(network.listified, attr),
+            info = paste("edge attribute", attr, "values")
+        )
+    }
+
+}, patrick::cases(
+    "remain.as.is: weight" = list(remain.as.is = c("weight")),
+    "remain.as.is: date" = list(remain.as.is = c("date")),
+    "remain.as.is: weight, date" = list(remain.as.is = c("weight", "date")),
+    "remain.as.is: default" = list(remain.as.is = NULL)
+))
+
+
+
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
 ## Extract data sources ----------------------------------------------------
 test_that("Get the data sources from a network with two relations", {

--- a/tests/test-split-misc.R
+++ b/tests/test-split-misc.R
@@ -109,11 +109,11 @@ test_that("Split network and data on low level (split.dataframe.by.bins, split.n
 
     ## results
     expected = list(
-        igraph::subgraph.edges(net, c(1,  5,  7)),
-        igraph::subgraph.edges(net, c(9, 12)),
-        igraph::subgraph.edges(net, c(2,  6,  8, 14)),
-        igraph::subgraph.edges(net, c(4, 11, 13)),
-        igraph::subgraph.edges(net, c(3, 10, 15))
+        igraph::subgraph_from_edges(net, c(1,  5,  7)),
+        igraph::subgraph_from_edges(net, c(9, 12)),
+        igraph::subgraph_from_edges(net, c(2,  6,  8, 14)),
+        igraph::subgraph_from_edges(net, c(4, 11, 13)),
+        igraph::subgraph_from_edges(net, c(3, 10, 15))
     )
     results = split.network.by.bins(net, bins, bins.vector)
 

--- a/tests/test-split-misc.R
+++ b/tests/test-split-misc.R
@@ -394,6 +394,7 @@ test_that("Check and correct duplicate range names during network activity-based
         igraph::edges(rep(c("A", "B"), times = length(dates)))
     ## set some date attributes that are appropriate for the test case
     net = igraph::set_edge_attr(net, "date", value = dates)
+    net = convert.edge.attributes.to.list(net)
 
     ## define split arguments
     split.function = split.network.activity.based

--- a/tests/test-split-network-activity-based.R
+++ b/tests/test-split-network-activity-based.R
@@ -62,10 +62,10 @@ patrick::with_parameters_test_that("Split a network activity-based (number.edges
 
     ## results
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(1, 2)),
-        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(3, 5)),
-        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(4, 7)),
-        "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(6, 8))
+        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph_from_edges(author.net, c(1, 2)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph_from_edges(author.net, c(3, 5)),
+        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph_from_edges(author.net, c(4, 7)),
+        "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(6, 8))
     )
     results = split.network.activity.based(author.net, number.edges = 2)
 
@@ -89,7 +89,7 @@ patrick::with_parameters_test_that("Split a network activity-based (number.edges
 
     ## results
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(1:igraph::ecount(author.net)))
+        "2016-07-12 15:58:59-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(1:igraph::ecount(author.net)))
     )
     results = split.network.activity.based(author.net, number.edges = igraph::ecount(author.net) + 10)
 
@@ -112,9 +112,9 @@ patrick::with_parameters_test_that("Split a network activity-based (number.edges
 
     ## results
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(1, 2, 3)),
-        "2016-07-12 16:05:41-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(4, 5, 7)),
-        "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(6, 8))
+        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph_from_edges(author.net, c(1, 2, 3)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:32" = igraph::subgraph_from_edges(author.net, c(4, 5, 7)),
+        "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(6, 8))
     )
     results = split.network.activity.based(author.net, number.windows = 3)
 
@@ -172,13 +172,13 @@ patrick::with_parameters_test_that("Split a network activity-based (number.edges
 
     ## results
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(1, 2)),
-        "2016-07-12 16:00:45-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(2, 3)),
-        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(3, 5)),
-        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(5, 4)),
-        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(4, 7)),
-        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(7, 6)),
-        "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(6, 8))
+        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph_from_edges(author.net, c(1, 2)),
+        "2016-07-12 16:00:45-2016-07-12 16:05:41" = igraph::subgraph_from_edges(author.net, c(2, 3)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph_from_edges(author.net, c(3, 5)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph_from_edges(author.net, c(5, 4)),
+        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph_from_edges(author.net, c(4, 7)),
+        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph_from_edges(author.net, c(7, 6)),
+        "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(6, 8))
     )
     results = split.network.activity.based(author.net, number.edges = 2, sliding.window = TRUE)
 
@@ -203,7 +203,7 @@ patrick::with_parameters_test_that("Split a network activity-based (number.edges
 
     ## results
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(1:igraph::ecount(author.net)))
+        "2016-07-12 15:58:59-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(1:igraph::ecount(author.net)))
     )
     results = split.network.activity.based(author.net, number.edges = igraph::ecount(author.net) + 10,
                                            sliding.window = TRUE)
@@ -227,9 +227,9 @@ patrick::with_parameters_test_that("Split a network activity-based (number.edges
 
     ## results
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(1, 2, 3)),
-        "2016-07-12 16:05:41-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(4, 5, 7)),
-        "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(6, 8))
+        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph_from_edges(author.net, c(1, 2, 3)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:32" = igraph::subgraph_from_edges(author.net, c(4, 5, 7)),
+        "2016-07-12 16:06:32-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(6, 8))
     )
     results = split.network.activity.based(author.net, number.windows = 3, sliding.window = TRUE)
 
@@ -284,14 +284,14 @@ patrick::with_parameters_test_that("Split a network activity-based (number.edges
 
     ## results
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(1, 2)),
-        "2016-07-12 16:00:45-2016-07-12 16:05:41" = igraph::subgraph.edges(author.net, c(2, 3)),
-        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(3, 5)),
-        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph.edges(author.net, c(5, 4)),
-        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(4, 7)),
-        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph.edges(author.net, c(7, 6)),
-        "2016-07-12 16:06:32-2020-02-20 20:20:20" = igraph::subgraph.edges(author.net, c(6, 8)),
-        "2016-07-12 16:06:32-2020-02-20 20:20:21" = igraph::subgraph.edges(author.net, c(8, 9))
+        "2016-07-12 15:58:59-2016-07-12 16:05:41" = igraph::subgraph_from_edges(author.net, c(1, 2)),
+        "2016-07-12 16:00:45-2016-07-12 16:05:41" = igraph::subgraph_from_edges(author.net, c(2, 3)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph_from_edges(author.net, c(3, 5)),
+        "2016-07-12 16:05:41-2016-07-12 16:06:10" = igraph::subgraph_from_edges(author.net, c(5, 4)),
+        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph_from_edges(author.net, c(4, 7)),
+        "2016-07-12 16:06:10-2016-07-12 16:06:32" = igraph::subgraph_from_edges(author.net, c(7, 6)),
+        "2016-07-12 16:06:32-2020-02-20 20:20:20" = igraph::subgraph_from_edges(author.net, c(6, 8)),
+        "2016-07-12 16:06:32-2020-02-20 20:20:21" = igraph::subgraph_from_edges(author.net, c(8, 9))
     )
     results = split.network.activity.based(author.net, number.edges = 2, sliding.window = TRUE)
 

--- a/tests/test-split-network-time-based.R
+++ b/tests/test-split-network-time-based.R
@@ -67,10 +67,10 @@ patrick::with_parameters_test_that("Split a network time-based (time.period = ..
     author.net = net.builder$get.author.network()
 
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:00:59" = igraph::subgraph.edges(author.net, c(1:2)),
-        "2016-07-12 16:00:59-2016-07-12 16:02:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:04:59-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(3:8))
+        "2016-07-12 15:58:59-2016-07-12 16:00:59" = igraph::subgraph_from_edges(author.net, c(1:2)),
+        "2016-07-12 16:00:59-2016-07-12 16:02:59" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:04:59-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(3:8))
     )
     results = split.network.time.based(author.net, time.period = "2 mins")
 
@@ -189,13 +189,13 @@ patrick::with_parameters_test_that("Split a network time-based (time.period = ..
     author.net = net.builder$get.author.network()
 
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:00:59" = igraph::subgraph.edges(author.net, c(1:2)),
-        "2016-07-12 15:59:59-2016-07-12 16:01:59" = igraph::subgraph.edges(author.net, c(2)),
-        "2016-07-12 16:00:59-2016-07-12 16:02:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:01:59-2016-07-12 16:03:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:03:59-2016-07-12 16:05:59" = igraph::subgraph.edges(author.net, c(3,5)),
-        "2016-07-12 16:04:59-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(3:8))
+        "2016-07-12 15:58:59-2016-07-12 16:00:59" = igraph::subgraph_from_edges(author.net, c(1:2)),
+        "2016-07-12 15:59:59-2016-07-12 16:01:59" = igraph::subgraph_from_edges(author.net, c(2)),
+        "2016-07-12 16:00:59-2016-07-12 16:02:59" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:01:59-2016-07-12 16:03:59" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:03:59-2016-07-12 16:05:59" = igraph::subgraph_from_edges(author.net, c(3,5)),
+        "2016-07-12 16:04:59-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(3:8))
     )
     results = split.network.time.based(author.net, time.period = "2 mins", sliding.window = TRUE)
 
@@ -264,10 +264,10 @@ patrick::with_parameters_test_that("Split a network time-based (bins = ...), ", 
 
     ## results
     expected = list(
-        "2016-07-12 15:58:00-2016-07-12 16:00:59" = igraph::subgraph.edges(author.net, c(1:2)),
-        "2016-07-12 16:00:59-2016-07-12 16:02:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:04:59-2016-07-12 17:21:43" = igraph::subgraph.edges(author.net, c(3:8))
+        "2016-07-12 15:58:00-2016-07-12 16:00:59" = igraph::subgraph_from_edges(author.net, c(1:2)),
+        "2016-07-12 16:00:59-2016-07-12 16:02:59" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:02:59-2016-07-12 16:04:59" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:04:59-2016-07-12 17:21:43" = igraph::subgraph_from_edges(author.net, c(3:8))
     )
     results = split.network.time.based(author.net, bins = bins, sliding.window = test.sliding.window)
 
@@ -377,10 +377,10 @@ patrick::with_parameters_test_that("Split a network time-based with equal-sized 
     author.net = net.builder$get.author.network()
 
     expected = list(
-        "2016-07-12 15:58:59-2016-07-12 16:00:53" = igraph::subgraph.edges(author.net, c(1:2)),
-        "2016-07-12 16:00:53-2016-07-12 16:02:47" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:02:47-2016-07-12 16:04:41" = igraph::subgraph.edges(author.net, c()),
-        "2016-07-12 16:04:41-2016-07-12 16:06:33" = igraph::subgraph.edges(author.net, c(3:8))
+        "2016-07-12 15:58:59-2016-07-12 16:00:53" = igraph::subgraph_from_edges(author.net, c(1:2)),
+        "2016-07-12 16:00:53-2016-07-12 16:02:47" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:02:47-2016-07-12 16:04:41" = igraph::subgraph_from_edges(author.net, c()),
+        "2016-07-12 16:04:41-2016-07-12 16:06:33" = igraph::subgraph_from_edges(author.net, c(3:8))
     )
     results = split.network.time.based(author.net, number.windows = 4)
 

--- a/util-misc.R
+++ b/util-misc.R
@@ -47,7 +47,7 @@ requireNamespace("lubridate") # for date conversion
 #' @return the new edgelist
 get.edgelist.with.timestamps = function(net) {
   ## get edge list as data.frame
-  edges = as.data.frame(igraph::get.edgelist(net))
+  edges = as.data.frame(igraph::as_edgelist(net))
   colnames(edges) = c("from", "to")
   ## get timestamps
   dates = igraph::edge_attr(net, "date")

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -173,7 +173,7 @@ add.vertex.attribute.commit.network = function(network, project.data,
         }
         attribute.values = c(attribute.values, value)
     }
-    net.with.attr = igraph::set.vertex.attribute(network, attr.name, value = attribute.values)
+    net.with.attr = igraph::set_vertex_attr(network, attr.name, value = attribute.values)
 }
 
 

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -234,7 +234,7 @@ metrics.scale.freeness = function(network, minimum.number.vertices = 30) {
 
     ## Power-law fiting
     ## (by  Mitchell Joblin <mitchell.joblin.ext@siemens.com>, Siemens AG,  2012, 2013)
-    p.fit = igraph::power.law.fit(v.degree, implementation = "plfit")
+    p.fit = igraph::fit_power_law(v.degree, implementation = "plfit", p.value = TRUE)
     param.names = c("alpha", "xmin", "KS.p")
     res = list()
     res[param.names] = p.fit[param.names]
@@ -250,7 +250,7 @@ metrics.scale.freeness = function(network, minimum.number.vertices = 30) {
        & non.zero.degree.v.count >= minimum.number.vertices) {
         ## vertex degree is sorted above
         x.min = v.degree[[minimum.number.vertices]]
-        p.fit = power.law.fit(v.degree, implementation = "plfit", xmin = x.min)
+        p.fit = igraph::fit_power_law(v.degree, implementation = "plfit", xmin = x.min, p.value = TRUE)
         res[param.names] = p.fit[param.names]
 
         ## Check percent of vertices under power-law

--- a/util-networks.R
+++ b/util-networks.R
@@ -1658,9 +1658,18 @@ merge.network.data = function(vertex.data, edge.data) {
     edge.data.filtered = Filter(function(ed) {
         return(nrow(ed) > 0)
     }, edge.data)
-    ## 2) call rbind
+    ## 2) add in missing columns
+    all.columns = Reduce(union, lapply(edge.data.filtered, colnames))
+    edge.data.filtered = lapply(edge.data.filtered, function(edges) {
+        missing.columns = setdiff(all.columns, colnames(edges))
+        for (column in missing.columns) {
+            edges[[column]] = NA
+        }
+        return(edges)
+    })
+    ## 3) call rbind
     edges = plyr::rbind.fill(edge.data.filtered)
-    ## 3) correct empty results
+    ## 4) correct empty results
     if (is.null(edges)) {
         edges = create.empty.edge.list()
     }

--- a/util-networks.R
+++ b/util-networks.R
@@ -1263,7 +1263,7 @@ NetworkBuilder = R6::R6Class("NetworkBuilder",
             if (igraph::is_directed(authors.net) && !igraph::is_directed(artifacts.net)) {
                 logging::logwarn(paste0("Author network is directed, but artifact network is not.",
                                         "Converting artifact network..."))
-                artifacts.net = igraph::as.directed(artifacts.net, mode = "mutual")
+                artifacts.net = igraph::as_directed(artifacts.net, mode = "mutual")
             } else if (!igraph::is_directed(authors.net) && igraph::is_directed(artifacts.net)) {
                 logging::logwarn(paste0("Author network is undirected, but artifact network is not.",
                                         "Converting artifact network..."))
@@ -1807,7 +1807,7 @@ add.edges.for.bipartite.relation = function(net, bipartite.relations, network.co
 #' @return the new empty network
 create.empty.network = function(directed = TRUE, add.attributes = FALSE) {
     ## create empty network
-    net = igraph::graph.empty(0, directed = directed)
+    net = igraph::make_empty_graph(0, directed = directed)
 
     # set proper attributes if wanted
     if (add.attributes) {
@@ -2074,7 +2074,9 @@ extract.bipartite.network.from.network = function(network, remove.isolates = FAL
     }
 
     ## only retain all bipartite edges and induced vertices
-    bip.network = igraph::subgraph.edges(network, igraph::E(network)[type == TYPE.EDGES.INTER], delete.vertices = remove.isolates)
+    bip.network = igraph::subgraph_from_edges(network,
+                                              igraph::E(network)[type == TYPE.EDGES.INTER],
+                                              delete.vertices = remove.isolates)
 
     return(bip.network)
 }

--- a/util-networks.R
+++ b/util-networks.R
@@ -22,7 +22,7 @@
 ## Copyright 2020 by Anselm Fehnker <anselm@muenster.de>
 ## Copyright 2021 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## Copyright 2022 by Jonathan Baumann <joba00002@stud.uni-saarland.de>
-## Copyright 2023-2024 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
+## Copyright 2023-2025 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
 ## Copyright 2024 by Leo Sendelbach <s8lesend@stud.uni-saarland.de>
 ## All Rights Reserved.
 
@@ -1282,16 +1282,19 @@ NetworkBuilder = R6::R6Class("NetworkBuilder",
             ## combine the networks:
             ## 1) merge the existing networks
             u = igraph::disjoint_union(authors.net, artifacts.net)
-            for (attr in igraph::edge_attr_names(u)) {
+
+            ## 2) replace NULLs in edge attributes with NAs for consistency
+            u = Reduce(function(u, attr) {
                 values = igraph::edge_attr(u, attr)
                 NULLs = sapply(values, is.null)
                 if (any(NULLs)) {
                     values[NULLs] = NA
                     u = igraph::set_edge_attr(u, attr, value = values)
                 }
-            }
+                return(u)
+            }, igraph::edge_attr_names(u), u)
 
-            ## 2) add the bipartite edges
+            ## 3) add the bipartite edges
             u = add.edges.for.bipartite.relation(u, authors.to.artifacts, private$network.conf)
 
             ## add range attribute for later analysis (if available)
@@ -1810,14 +1813,16 @@ add.edges.for.bipartite.relation = function(net, bipartite.relations, network.co
         ## add the vertex sequences as edges to the network
         net = igraph::add_edges(net, unlist(vertex.sequence.for.edges), attr = extra.edge.attributes)
 
-        for (attr in igraph::edge_attr_names(net)) {
+        ## replace NULLs in edge attributes with NAs for consistency
+        net = Reduce(function(net, attr) {
             values = igraph::edge_attr(net, attr)
             NULLs = sapply(values, is.null)
             if (any(NULLs)) {
                 values[NULLs] = NA
                 net = igraph::set_edge_attr(net, attr, value = values)
             }
-        }
+            return(net)
+        }, igraph::edge_attr_names(net), net)
     }
 
     return(net)

--- a/util-networks.R
+++ b/util-networks.R
@@ -1282,6 +1282,14 @@ NetworkBuilder = R6::R6Class("NetworkBuilder",
             ## combine the networks:
             ## 1) merge the existing networks
             u = igraph::disjoint_union(authors.net, artifacts.net)
+            for (attr in igraph::edge_attr_names(u)) {
+                values = igraph::edge_attr(u, attr)
+                NULLs = sapply(values, is.null)
+                if (any(NULLs)) {
+                    values[NULLs] = NA
+                    u = igraph::set_edge_attr(u, attr, value = values)
+                }
+            }
 
             ## 2) add the bipartite edges
             u = add.edges.for.bipartite.relation(u, authors.to.artifacts, private$network.conf)
@@ -1792,6 +1800,15 @@ add.edges.for.bipartite.relation = function(net, bipartite.relations, network.co
 
         ## add the vertex sequences as edges to the network
         net = igraph::add_edges(net, unlist(vertex.sequence.for.edges), attr = extra.edge.attributes)
+
+        for (attr in igraph::edge_attr_names(net)) {
+            values = igraph::edge_attr(net, attr)
+            NULLs = sapply(values, is.null)
+            if (any(NULLs)) {
+                values[NULLs] = NA
+                net = igraph::set_edge_attr(net, attr, value = values)
+            }
+        }
     }
 
     return(net)

--- a/util-read.R
+++ b/util-read.R
@@ -949,6 +949,10 @@ read.commit.interactions = function(data.path = NULL) {
             interacting.hashes.df[["base.file"]] = base.file.name
             return(interacting.hashes.df)
         })))
+        ## Return an empty data frame if the current interaction is empty (i.e., if an interaction is not existent).
+        if (nrow(interactions) == 0) {
+          return(data.frame())
+        }
         ## Initialize author data as 'NA', since it is not available from the commit-interaction data.
         ## Author data will be merged from commit data in \code{update.commit.interactions}.
         interactions["base.author"] = NA_character_

--- a/util-split.R
+++ b/util-split.R
@@ -834,6 +834,11 @@ split.network.time.based.by.ranges = function(network, ranges, remove.isolates =
         }
     )
 
+    # add range information
+    if (is.null(names(nets.split))) {
+        names(nets.split) = ranges
+    }
+
     ## convert ranges to bins
     bins = get.bin.dates.from.ranges(ranges.bounds)
     attr(nets.split, "bins") = bins

--- a/util-split.R
+++ b/util-split.R
@@ -836,7 +836,7 @@ split.network.time.based.by.ranges = function(network, ranges, remove.isolates =
         }
     )
 
-    # add range information
+    ## add range information
     if (is.null(names(nets.split))) {
         names(nets.split) = ranges
     }

--- a/util-split.R
+++ b/util-split.R
@@ -876,7 +876,7 @@ split.network.by.bins = function(network, bins, bins.vector, bins.date = NULL, r
         ## identify edges in the current bin
         edges = igraph::E(network)[ bins.vector == bin ]
         ## create network based on the current set of edges
-        g = igraph::subgraph.edges(network, edges, delete.vertices = remove.isolates)
+        g = igraph::subgraph_from_edges(network, edges, delete.vertices = remove.isolates)
         return(g)
     })
     ## set 'bins' attribute, if specified

--- a/util-split.R
+++ b/util-split.R
@@ -524,7 +524,8 @@ split.network.time.based = function(network, time.period = "3 months", bins = NU
                                     number.windows = NULL,  sliding.window = FALSE,
                                     remove.isolates = TRUE) {
     ## extract date attributes from edges
-    dates = get.date.from.unix.timestamp(igraph::edge_attr(network, "date"))
+    dates = do.call(base::c, igraph::edge_attr(network, "date"))
+    dates = get.date.from.unix.timestamp(dates)
 
     ## number of windows given (ignoring time period and bins)
     if (!is.null(number.windows)) {
@@ -619,7 +620,7 @@ split.networks.time.based = function(networks, time.period = "3 months", bins = 
             dates = igraph::E(net)$date
             return(dates)
         })
-        dates = unlist(networks.dates, recursive = FALSE)
+        dates = unlist(networks.dates)
         dates = get.date.from.unix.timestamp(dates)
 
         ## 2) get bin information
@@ -708,8 +709,9 @@ split.network.activity.based = function(network, number.edges = 5000, number.win
                      number.edges, number.windows)
 
     ## get dates in a data.frame for splitting purposes
+    dates = do.call(base::c, igraph::edge_attr(network, "date"))
     df = data.frame(
-        date = get.date.from.unix.timestamp(igraph::edge_attr(network, "date")),
+        date = get.date.from.unix.timestamp(dates),
         my.unique.id = seq_len(edge.count) # as a unique identifier only
     )
     ## sort by date


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

<!-- Add a description of the added/changed/fixed functionality in this pull request. -->

* Replace deprecated `igraph` functions by their more recent counterparts.
* Handle reading empty commit interaction data explicitly, to avoid crashing in that case.
* To make splitting networks by ranges more consistent with splitting time-based, also add range information to the return value.
* Convert certain edge attributes of networks to list type. This change is motivated by a more stricter type enforcement in `igraph` version 2.0 and up. When merging networks through `igraph::disjoint_union`, edge attributes that exist in both networks are now assumed to have identical types. But, when we simplify a network, its edge attributes convert to list type as they now need to store data that a vector in R cannot store anymore, i.e., one edge attribute now has to hold several *lists* of data of all the edges that got merged into one. Therefore, we need to convert edge attributes to list by default to be able to merge simplified and unsimplified networks.

### Changelog

<!-- Put the updated/added parts of the changelog here. -->

#### Added

* Introduce `convert.edge.attributes.to.list` function.

#### Fixed

* Fix reading empty commit interaction data.

#### Changed / Improved

* Replace deprecated `igraph` functions.
* Add range information to the return value in `split.network.time.based.by.ranges`, to be consistent with `split.data.time.based`.
* Convert edge attributes to a list format to ensure compatibility with `igraph`.
