### PR TITLE
Add functions to compute a developer's last activity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - Add commit network as a new type of network. It uses commits as vertices and connects them either via cochange or commit interactions. This includes adding new config parameters and the function `add.vertex.attribute.commit.network` for adding vertex attributes to a commit network (PR #263, ab73271781e8e9a0715f784936df4b371d64c338, ab73271781e8e9a0715f784936df4b371d64c338, cd9a930fcb54ff465c2a5a7c43cfe82ac15c134d)
 - Add `remove.duplicate.edges` function that takes a network as input and conflates identical edges (PR #268, d9a4be417b340812b744f59398ba6460ba527e1c, 0c2f47c4fea6f5f2f582c0259f8cf23af985058a, c6e90dd9cb462232563f753f414da14a24b392a3)
 - Add `cumulative` as an argument to `construct.ranges` which enables the creation of cumulative ranges from given revisions (PR #268, a135f6bb6f83ccb03ae27c735c2700fccc1ee0c8, 8ec207f1e306ef6a641fb0205a9982fa89c7e0d9)
+- Add function `get.last.activity.data` to compute developers' last activities in a project, as well as function `add.vertex.attribute.author.last.activity` to add a developer's date of last activity as vertex attribute to a network, as well as helper functions `get.aggregated.activity.data` and `add.vertex.attribute.author.aggregated.activity` to allow for other activity aggregations than first and last activity (PR #275, 9f231612fcd33a283362c79b35a94295ff3d4ef9, 8660ed763ba4b69e909e7fbb01e27e1999522047)
 
 ### Changed/Improved
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Have you ever wanted to build socio-technical developer networks the way you want? Here, you are in the right place. Using this network library, you are able to construct such networks based on various data sources (commits, e-mails, issues) in a configurable and modular way. Additionally, we provide, e.g., analysis methods for network motifs, network metrics, and developer classification.
 
-The network library `coronet` can be used to construct analyzable networks based on data extracted from `Codeface` [[https://github.com/siemens/codeface](https://github.com/siemens/codeface)] and its companion tool `codeface-extraction` [[https://github.com/se-sic/codeface-extraction](https://github.com/se-sic/codeface-extraction)]. The library reads the written/extracted data from disk and constructs intermediate data structures for convenient data handling, either *data containers* or, more importantly, *developer networks*.
+The network library `coronet` can be used to construct analyzable networks based on data extracted from `Codeface` [[https://github.com/se-sic/codeface](https://github.com/se-sic/codeface)] (originally developed by Siemens) and its companion tool `codeface-extraction` [[https://github.com/se-sic/codeface-extraction](https://github.com/se-sic/codeface-extraction)]. The library reads the written/extracted data from disk and constructs intermediate data structures for convenient data handling, either *data containers* or, more importantly, *developer networks*.
 
 If you wonder: The name `coronet` derives as an acronym from the words "configurable", "reproducible", and, most importantly, "network". The name says it all and very much conveys our goal.
 
@@ -112,7 +112,7 @@ While `proximity` triggers a file/function-based commit analysis in `Codeface`, 
 When using this network library, the user only needs to give the `artifact` parameter to the [`ProjectConf`](#projectconf) constructor, which automatically ensures that the correct tagging is selected.
 
 The configuration files `{project-name}_{tagging}.conf` are mandatory and contain some basic configuration regarding a performed `Codeface` analysis (e.g., project name, name of the corresponding repository, name of the mailing list, etc.).
-For further details on those files, please have a look at some [example files](https://github.com/siemens/codeface/tree/master/conf) in the `Codeface` repository.
+For further details on those files, please have a look at some [example files](https://github.com/se-sic/codeface/tree/infosaar-updates/conf) in the `Codeface` repository.
 
 All the `*.list` files listed above are output files of `codeface-extraction` and contain meta data of, e.g., commits or e-mails to the mailing list, etc., in CSV format.
 This network library lazily loads and processes these files when needed.

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -16,6 +16,7 @@
 ## Copyright 2021 by Christian Hechtl <hechtl@cs.uni-saarland.de>
 ## Copyright 2017-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2018-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2024 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018-2019 by Klara Schlüter <schluete@fim.uni-passau.de>
 ## Copyright 2018-2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
@@ -286,6 +287,228 @@ get.expected.first.activity = function() {
                 list(
                     mails = "2016-07-12 15:58:50 UTC",
                     commits = "2016-07-12 16:00:45 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = NA,
+                    commits = "2016-07-12 16:06:10 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = "2016-07-12 16:04:40 UTC",
+                    commits = "2016-07-12 16:06:32 UTC",
+                    issues = NA
+                )
+            )
+        )
+    )
+
+    ## convert date strings to POSIXct
+    expected.attributes = lapply(expected.attributes, function(level) {
+        lapply(level, function(network) {
+            lapply(network, function(person) {
+                lapply(person, function(date.per.datasource) {
+                    return(get.date.from.string(date.per.datasource))
+                })
+            })
+        })
+    })
+
+    return(expected.attributes)
+}
+
+#' Helper for the last activitity tests: Gets the last activity per person and data source for possible
+#' aggregation levels as a nested list.
+#'
+#' @return A list (elements represent the levels) of lists (elements represent the networks after splitting) of lists
+#'         (elements represent the vertices which represent persons) of lists (elements represent the different data
+#'         sources) of dates as PoSIXct.
+get.expected.last.activity = function() {
+    expected.attributes = list(
+        range = network.covariates.test.build.expected(
+            list(
+                list(
+                    mails = "2016-07-12 15:58:40 UTC",
+                    commits = "2016-07-12 15:58:59 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = NA,
+                    commits = "2016-07-12 16:00:45 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37 UTC",
+                    commits = "2016-07-12 16:05:41 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = NA,
+                    commits = "2016-07-12 16:06:10 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = NA,
+                    commits = "2016-07-12 16:06:32 UTC",
+                    issues = NA
+                )
+            )
+        ),
+        cumulative = network.covariates.test.build.expected(
+            list(
+                list(
+                    mails = "2016-07-12 15:58:40 UTC",
+                    commits = "2016-07-12 15:58:59 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 15:58:50 UTC",
+                    commits = "2016-07-12 16:00:45 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37 UTC",
+                    commits = "2016-07-12 16:05:41 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = NA,
+                    commits = "2016-07-12 16:06:10 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = "2016-07-12 16:04:40 UTC",
+                    commits = "2016-07-12 16:06:32 UTC",
+                    issues = NA
+                )
+            )
+        ),
+        all.ranges = network.covariates.test.build.expected(
+            list(
+                list(
+                    mails = "2016-07-12 15:58:40 UTC",
+                    commits = "2016-07-12 15:58:59 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37 UTC",
+                    commits = "2016-07-12 16:05:41 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37 UTC",
+                    commits = "2016-07-12 16:05:41 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = NA,
+                    commits = "2016-07-12 16:06:10 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = "2016-07-12 16:04:40 UTC",
+                    commits = "2016-07-12 16:06:32 UTC",
+                    issues = NA
+                )
+            )
+        ),
+        project.cumulative = network.covariates.test.build.expected(
+            list(
+                list(
+                    mails = "2016-07-12 15:58:40 UTC",
+                    commits = "2016-07-12 15:58:59 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 15:58:50 UTC",
+                    commits = "2016-07-12 16:00:45 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37 UTC",
+                    commits = "2016-07-12 16:05:41 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = NA,
+                    commits = "2016-07-12 16:06:10 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = "2016-07-12 16:04:40 UTC",
+                    commits = "2016-07-12 16:06:32 UTC",
+                    issues = NA
+                )
+            )
+        ),
+        project.all.ranges = network.covariates.test.build.expected(
+            list(
+                list(
+                    mails = "2016-07-12 15:58:40 UTC",
+                    commits = "2016-07-12 15:58:59 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37 UTC",
+                    commits = "2016-07-12 16:05:41 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37 UTC",
+                    commits = "2016-07-12 16:05:41 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = NA,
+                    commits = "2016-07-12 16:06:10 UTC",
+                    issues = NA
+                ),
+                list(
+                    mails = "2016-07-12 16:04:40 UTC",
+                    commits = "2016-07-12 16:06:32 UTC",
+                    issues = NA
+                )
+            )
+        ),
+        complete = network.covariates.test.build.expected(
+            list(
+                list(
+                    mails = "2016-07-12 15:58:40 UTC",
+                    commits = "2016-07-12 15:58:59 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37",
+                    commits = "2016-07-12 16:05:41 UTC",
+                    issues = NA
+                )
+            ),
+            list(
+                list(
+                    mails = "2016-07-12 16:05:37",
+                    commits = "2016-07-12 16:05:41 UTC",
                     issues = NA
                 ),
                 list(
@@ -1039,6 +1262,152 @@ test_that("Test add.vertex.attribute.author.first.activity with one type and com
             default.value = NA, combine.activity.types = FALSE
         )
         actual.attributes = lapply(networks.with.attributes, igraph::vertex_attr, name = "first.activity")
+
+        expect_equal(expected.attributes[[level]], actual.attributes)
+    })
+})
+
+#' Test the add.vertex.attribute.author.last.activity method with computation over all types.
+test_that("Test add.vertex.attribute.author.last.activity with multiple types and computation over all types", {
+
+    ## Test setup
+
+    networks.and.data = get.network.covariates.test.networks()
+
+    ## lock issues in order to prevent them from being read because that alters the first activity dates
+    networks.and.data$project.data$set.project.conf.entry("issues.locked", TRUE)
+
+    expected.attributes = list(
+        range = network.covariates.test.build.expected(
+            list(list(all.activities = "2016-07-12 15:58:59 UTC")),
+            list(list(all.activities = "2016-07-12 16:00:45 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC"),
+                 list(all.activities = "2016-07-12 16:06:10 UTC"),
+                 list(all.activities = "2016-07-12 16:06:32 UTC")
+            )
+        ),
+        cumulative = network.covariates.test.build.expected(
+            list(list(all.activities = "2016-07-12 15:58:59 UTC")),
+            list(list(all.activities = "2016-07-12 16:00:45 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC"),
+                 list(all.activities = "2016-07-12 16:06:10 UTC"),
+                 list(all.activities = "2016-07-12 16:06:32 UTC")
+            )
+        ),
+        all.ranges = network.covariates.test.build.expected(
+            list(list(all.activities = "2016-07-12 15:58:59 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC"),
+                 list(all.activities = "2016-07-12 16:06:10 UTC"),
+                 list(all.activities = "2016-07-12 16:06:32 UTC")
+            )
+        ),
+        project.cumulative = network.covariates.test.build.expected(
+            list(list(all.activities = "2016-07-12 15:58:59 UTC")),
+            list(list(all.activities = "2016-07-12 16:00:45 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC"),
+                 list(all.activities = "2016-07-12 16:06:10 UTC"),
+                 list(all.activities = "2016-07-12 16:06:32 UTC")
+            )
+        ),
+        project.all.ranges = network.covariates.test.build.expected(
+            list(list(all.activities = "2016-07-12 15:58:59 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC"),
+                 list(all.activities = "2016-07-12 16:06:10 UTC"),
+                 list(all.activities = "2016-07-12 16:06:32 UTC")
+            )
+        ),
+        complete = network.covariates.test.build.expected(
+            list(list(all.activities = "2016-07-12 15:58:59 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC")),
+            list(list(all.activities = "2016-07-12 16:05:41 UTC"),
+                 list(all.activities = "2016-07-12 16:06:10 UTC"),
+                 list(all.activities = "2016-07-12 16:06:32 UTC")
+            )
+        )
+    )
+
+    ## convert date strings to POSIXct
+    expected.attributes = lapply(expected.attributes, function(level) {
+        lapply(level, function(network) {
+            lapply(network, function(person) {
+                lapply(person, function(date.per.datasource) {
+                    return(get.date.from.string(date.per.datasource))
+                })
+            })
+        })
+    })
+
+    ## Test
+
+    lapply(AGGREGATION.LEVELS, function(level) {
+
+        networks.with.attributes = add.vertex.attribute.author.last.activity(
+            list.of.networks = networks.and.data[["networks"]], project.data = networks.and.data[["project.data"]],
+            activity.types = c("mails", "commits", "issues"), name = "last.activity", aggregation.level = level,
+            default.value = NA, combine.activity.types = TRUE
+        )
+        actual.attributes = lapply(networks.with.attributes, igraph::vertex_attr, name = "last.activity")
+
+        expect_equal(expected.attributes[[level]], actual.attributes)
+    })
+})
+
+#' Test the add.vertex.attribute.author.last.activity method with multiple activity types and computation per type.
+test_that("Test add.vertex.attribute.author.last.activity with multiple types and computation per type", {
+
+    ## Test setup
+
+    networks.and.data = get.network.covariates.test.networks()
+
+    expected.attributes = get.expected.last.activity()
+
+    ## lock issues in order to prevent them from being read because that alters the first activity dates
+    networks.and.data$project.data$set.project.conf.entry("issues.locked", TRUE)
+
+    ## Test
+
+    lapply(AGGREGATION.LEVELS, function(level) {
+
+        networks.with.attributes = add.vertex.attribute.author.last.activity(
+            list.of.networks = networks.and.data[["networks"]], project.data = networks.and.data[["project.data"]],
+            activity.types = c("mails", "commits", "issues"), name = "last.activity", aggregation.level = level,
+            default.value = NA, combine.activity.types = FALSE
+        )
+        actual.attributes = lapply(networks.with.attributes, igraph::vertex_attr, name = "last.activity")
+
+        expect_equal(expected.attributes[[level]], actual.attributes)
+    })
+})
+
+#' Test the add.vertex.attribute.author.last.activity method with one activity type and computation per type.
+test_that("Test add.vertex.attribute.author.last.activity with one type and computation per type", {
+
+    ## Test setup
+
+    networks.and.data = get.network.covariates.test.networks()
+
+    expected.attributes = get.expected.last.activity()
+    expected.attributes = lapply(expected.attributes, function(level) {
+        lapply(level, function(network) {
+            lapply(network, function(person) {
+                return(person["mails"])
+            })
+        })
+    })
+
+
+    ## Test
+
+    lapply(AGGREGATION.LEVELS, function(level) {
+
+        networks.with.attributes = add.vertex.attribute.author.last.activity(
+            list.of.networks = networks.and.data[["networks"]], project.data = networks.and.data[["project.data"]],
+            activity.types = c("mails"), name = "last.activity", aggregation.level = level,
+            default.value = NA, combine.activity.types = FALSE
+        )
+        actual.attributes = lapply(networks.with.attributes, igraph::vertex_attr, name = "last.activity")
 
         expect_equal(expected.attributes[[level]], actual.attributes)
     })

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -14,7 +14,7 @@
 ## Copyright 2017 by Felix Prasse <prassefe@fim.uni-passau.de>
 ## Copyright 2018-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2018-2019 by Thomas Bock <bockthom@fim.uni-passau.de>
-## Copyright 2021, 2023-2024 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2021, 2023-2025 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2018-2019 by Klara Schlüter <schluete@fim.uni-passau.de>
 ## Copyright 2018 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## Copyright 2020 by Christian Hechtl <hechtl@cs.uni-saarland.de>
@@ -325,13 +325,13 @@ add.vertex.attribute.author.commit.count.committer = function(list.of.networks, 
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.commit.count.committer.not.author = function(list.of.networks, project.data,
-                                                                  name = "commit.count.committer.not.author",
-                                                                  aggregation.level = c("range", "cumulative",
-                                                                                        "all.ranges",
-                                                                                        "project.cumulative",
-                                                                                        "project.all.ranges",
-                                                                                        "complete"),
-                                                                  default.value = 0L) {
+                                                                         name = "commit.count.committer.not.author",
+                                                                         aggregation.level = c("range", "cumulative",
+                                                                                               "all.ranges",
+                                                                                               "project.cumulative",
+                                                                                               "project.all.ranges",
+                                                                                               "complete"),
+                                                                         default.value = 0L) {
     nets.with.attr = add.vertex.attribute.count.helper(
         list.of.networks, project.data, name, aggregation.level,
         default.value, get.committer.not.author.commit.count, "committer.name"
@@ -354,13 +354,13 @@ add.vertex.attribute.author.commit.count.committer.not.author = function(list.of
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.commit.count.committer.and.author = function(list.of.networks, project.data,
-                                                                  name = "commit.count.committer.and.author",
-                                                                  aggregation.level = c("range", "cumulative",
-                                                                                        "all.ranges",
-                                                                                        "project.cumulative",
-                                                                                        "project.all.ranges",
-                                                                                        "complete"),
-                                                                  default.value = 0L) {
+                                                                         name = "commit.count.committer.and.author",
+                                                                         aggregation.level = c("range", "cumulative",
+                                                                                               "all.ranges",
+                                                                                               "project.cumulative",
+                                                                                               "project.all.ranges",
+                                                                                               "complete"),
+                                                                         default.value = 0L) {
     nets.with.attr = add.vertex.attribute.count.helper(
         list.of.networks, project.data, name, aggregation.level,
         default.value, get.committer.and.author.commit.count, "committer.name"
@@ -384,13 +384,13 @@ add.vertex.attribute.author.commit.count.committer.and.author = function(list.of
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.commit.count.committer.or.author = function(list.of.networks, project.data,
-                                                                  name = "commit.count.committer.or.author",
-                                                                  aggregation.level = c("range", "cumulative",
-                                                                                        "all.ranges",
-                                                                                        "project.cumulative",
-                                                                                        "project.all.ranges",
-                                                                                        "complete"),
-                                                                  default.value = 0L) {
+                                                                        name = "commit.count.committer.or.author",
+                                                                        aggregation.level = c("range", "cumulative",
+                                                                                              "all.ranges",
+                                                                                              "project.cumulative",
+                                                                                              "project.all.ranges",
+                                                                                              "complete"),
+                                                                        default.value = 0L) {
     nets.with.attr = add.vertex.attribute.count.helper(
         list.of.networks, project.data, name, aggregation.level,
         default.value, get.committer.or.author.commit.count, "name"
@@ -414,10 +414,10 @@ add.vertex.attribute.author.commit.count.committer.or.author = function(list.of.
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.artifact.count = function(list.of.networks, project.data, name = "artifact.count",
-                                               aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                     "project.cumulative", "project.all.ranges",
-                                                                     "complete"),
-                                               default.value = 0L) {
+                                                      aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                            "project.cumulative", "project.all.ranges",
+                                                                            "complete"),
+                                                      default.value = 0L) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "range")
 
     nets.with.attr = split.and.add.vertex.attribute(
@@ -452,11 +452,11 @@ add.vertex.attribute.author.artifact.count = function(list.of.networks, project.
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.mail.count = function(list.of.networks, project.data,
-                                           name = "mail.count",
-                                           aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                 "project.cumulative", "project.all.ranges",
-                                                                 "complete"),
-                                           default.value = 0L) {
+                                                  name = "mail.count",
+                                                  aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                        "project.cumulative", "project.all.ranges",
+                                                                        "complete"),
+                                                  default.value = 0L) {
     nets.with.attr = add.vertex.attribute.count.helper(
         list.of.networks, project.data, name, aggregation.level,
         default.value, get.author.mail.count, "author.name"
@@ -479,11 +479,11 @@ add.vertex.attribute.author.mail.count = function(list.of.networks, project.data
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.mail.thread.count = function(list.of.networks, project.data,
-                                           name = "mail.thread.count",
-                                           aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                 "project.cumulative", "project.all.ranges",
-                                                                 "complete"),
-                                           default.value = 0L) {
+                                                         name = "mail.thread.count",
+                                                         aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                               "project.cumulative",
+                                                                               "project.all.ranges", "complete"),
+                                                         default.value = 0L) {
     nets.with.attr = add.vertex.attribute.count.helper(
         list.of.networks, project.data, name, aggregation.level,
         default.value, get.author.mail.thread.count, "author.name"
@@ -511,12 +511,13 @@ add.vertex.attribute.author.mail.thread.count = function(list.of.networks, proje
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.issue.count = function(list.of.networks, project.data,
-                                            name = "issue.count",
-                                            aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                  "project.cumulative", "project.all.ranges",
-                                                                  "complete"),
-                                            default.value = 0L, issue.type = c("all", "pull.requests", "issues"),
-                                            use.unfiltered.data = FALSE) {
+                                                   name = "issue.count",
+                                                   aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                         "project.cumulative", "project.all.ranges",
+                                                                         "complete"),
+                                                   default.value = 0L,
+                                                   issue.type = c("all", "pull.requests", "issues"),
+                                                   use.unfiltered.data = FALSE) {
     issue.type = match.arg(issue.type)
 
     if (missing(name) && identical(issue.type, "pull.requests")) {
@@ -550,14 +551,13 @@ add.vertex.attribute.author.issue.count = function(list.of.networks, project.dat
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.issues.commented.count = function(list.of.networks, project.data,
-                                                          name = "issues.commented.count",
-                                                          aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                                "project.cumulative",
-                                                                                "project.all.ranges",
-                                                                                "complete"),
-                                                          default.value = 0L, issue.type = c("all", "pull.requests",
-                                                                                             "issues"),
-                                                          use.unfiltered.data = FALSE) {
+                                                              name = "issues.commented.count",
+                                                              aggregation.level = c("range", "cumulative",
+                                                                                    "all.ranges", "project.cumulative",
+                                                                                    "project.all.ranges", "complete"),
+                                                              default.value = 0L,
+                                                              issue.type = c("all", "pull.requests", "issues"),
+                                                              use.unfiltered.data = FALSE) {
     issue.type = match.arg(issue.type)
 
     if (missing(name) && identical(issue.type, "pull.requests")) {
@@ -594,14 +594,13 @@ add.vertex.attribute.author.issues.commented.count = function(list.of.networks, 
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.issue.creation.count = function(list.of.networks, project.data,
-                                                          name = "issue.creation.count",
-                                                          aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                                "project.cumulative",
-                                                                                "project.all.ranges",
-                                                                                "complete"),
-                                                          default.value = 0L, issue.type = c("all", "pull.requests",
-                                                                                             "issues"),
-                                                          use.unfiltered.data = TRUE) {
+                                                            name = "issue.creation.count",
+                                                            aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                                  "project.cumulative",
+                                                                                  "project.all.ranges", "complete"),
+                                                            default.value = 0L,
+                                                            issue.type = c("all", "pull.requests", "issues"),
+                                                            use.unfiltered.data = TRUE) {
     issue.type = match.arg(issue.type)
 
     if (missing(name) && identical(issue.type, "pull.requests")) {
@@ -634,14 +633,13 @@ add.vertex.attribute.author.issue.creation.count = function(list.of.networks, pr
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.issue.comment.count = function(list.of.networks, project.data,
-                                                          name = "issue.comment.count",
-                                                          aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                                "project.cumulative",
-                                                                                "project.all.ranges",
-                                                                                "complete"),
-                                                          default.value = 0L, issue.type = c("all", "pull.requests",
-                                                                                             "issues"),
-                                                          use.unfiltered.data = FALSE) {
+                                                           name = "issue.comment.count",
+                                                           aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                                 "project.cumulative",
+                                                                                 "project.all.ranges", "complete"),
+                                                           default.value = 0L,
+                                                           issue.type = c("all", "pull.requests", "issues"),
+                                                           use.unfiltered.data = FALSE) {
     issue.type = match.arg(issue.type)
 
     if (missing(name) && identical(issue.type, "pull.requests")) {
@@ -781,8 +779,8 @@ add.vertex.attribute.author.aggregated.activity = function(list.of.networks, pro
                                                            activity.types = c("mails", "commits", "issues"),
                                                            name = "aggregated.activity",
                                                            aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                                 "project.cumulative", "project.all.ranges",
-                                                                                 "complete"),
+                                                                                 "project.cumulative",
+                                                                                 "project.all.ranges", "complete"),
                                                            default.value = NA,
                                                            combine.activity.types = FALSE,
                                                            aggregation.function,
@@ -843,9 +841,9 @@ add.vertex.attribute.author.aggregated.activity = function(list.of.networks, pro
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.author.active.ranges = function(list.of.networks, project.data, name = "active.ranges",
-                                              activity.types = c("mails", "commits", "issues"),
-                                              default.value = list(),
-                                              combine.activity.types = FALSE) {
+                                                     activity.types = c("mails", "commits", "issues"),
+                                                     default.value = list(),
+                                                     combine.activity.types = FALSE) {
     net.to.range.list = split.data.by.networks(list.of.networks, project.data, "range")
     parsed.activity.types = match.arg.or.default(activity.types, several.ok = TRUE)
 
@@ -940,8 +938,8 @@ add.vertex.attribute.author.role.simple = function(list.of.networks, project.dat
 add.vertex.attribute.author.role.function = function(list.of.networks, project.data, classification.function,
                                                      name = "author.role",
                                                      aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                          "project.cumulative", "project.all.ranges",
-                                                                          "complete"),
+                                                                           "project.cumulative", "project.all.ranges",
+                                                                           "complete"),
                                                      default.value = NA) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "range")
 
@@ -1113,8 +1111,7 @@ add.vertex.attribute.artifact.change.count = function(list.of.networks, project.
 add.vertex.attribute.artifact.first.occurrence = function(list.of.networks, project.data, name = "first.occurrence",
                                                           aggregation.level = c("range", "cumulative", "all.ranges",
                                                                                 "project.cumulative",
-                                                                                "project.all.ranges",
-                                                                                "complete"),
+                                                                                "project.all.ranges", "complete"),
                                                           default.value = NA) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "complete")
 
@@ -1148,11 +1145,10 @@ add.vertex.attribute.artifact.first.occurrence = function(list.of.networks, proj
 #'
 #' @return A list of networks with the added attribute
 add.vertex.attribute.artifact.last.edited = function(list.of.networks, project.data, name = "last.edited",
-                                                          aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                                "project.cumulative",
-                                                                                "project.all.ranges",
-                                                                                "complete"),
-                                                          default.value = NA) {
+                                                     aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                           "project.cumulative",
+                                                                           "project.all.ranges", "complete"),
+                                                     default.value = NA) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "complete")
 
     ## make sure that the default value contains a tzone attribute (even if the default value is NA)
@@ -1219,8 +1215,7 @@ add.vertex.attribute.mail.thread.contributor.count = function(list.of.networks, 
 add.vertex.attribute.mail.thread.message.count = function(list.of.networks, project.data, name = "thread.message.count",
                                                           aggregation.level = c("range", "cumulative", "all.ranges",
                                                                                 "project.cumulative",
-                                                                                "project.all.ranges",
-                                                                                "complete"),
+                                                                                "project.all.ranges", "complete"),
                                                           default.value = NA) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "complete")
 
@@ -1249,8 +1244,7 @@ add.vertex.attribute.mail.thread.message.count = function(list.of.networks, proj
 add.vertex.attribute.mail.thread.start.date = function(list.of.networks, project.data, name = "thread.start.date",
                                                        aggregation.level = c("range", "cumulative", "all.ranges",
                                                                              "project.cumulative",
-                                                                             "project.all.ranges",
-                                                                             "complete"),
+                                                                             "project.all.ranges", "complete"),
                                                        default.value = NA) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "complete")
 
@@ -1392,8 +1386,8 @@ add.vertex.attribute.issue.event.count = function(list.of.networks, project.data
                                                   aggregation.level = c("range", "cumulative", "all.ranges",
                                                                         "project.cumulative", "project.all.ranges",
                                                                         "complete"),
-                                                  type = c("all", "issues", "pull.requests"), default.value = NA,
-                                                  use.unfiltered.data = FALSE) {
+                                                  type = c("all", "issues", "pull.requests"),
+                                                  default.value = NA, use.unfiltered.data = FALSE) {
     type = match.arg(type)
     aggregation.level = match.arg.or.default(aggregation.level, default = "complete")
     if (missing(name) && identical(type, "pull.requests")) {

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -688,30 +688,105 @@ add.vertex.attribute.author.email = function(list.of.networks, project.data, nam
 
 #' Add first activity attribute.
 #'
-#' @param list.of.networks The network list.
-#' @param project.data The project data.
+#' @param list.of.networks The network list
+#' @param project.data The project data
 #' @param activity.types The kinds of activity to use as basis: One or more of \code{mails}, \code{commits} and
-#'                       \code{issues}. [default: c("mails", "commits", "issues")]
-#' @param name The attribute name to add. [default: "first.activity"]
+#'                       \code{issues} [default: c("mails", "commits", "issues")]
+#' @param name The attribute name to add [default: "first.activity"]
 #' @param aggregation.level Determines the data to use for the attribute calculation.
 #'                          One of \code{"range"}, \code{"cumulative"}, \code{"all.ranges"},
 #'                          \code{"project.cumulative"}, \code{"project.all.ranges"}, and
 #'                          \code{"complete"}. See \code{split.data.by.networks} for
 #'                          more details. [default: "complete"]
-#' @param default.value The default value to add if a vertex has no matching value. [default: NA].
+#' @param default.value The default value to add if a vertex has no matching value [default: NA]
 #' @param combine.all.activity.types Flag indicating that one value, computed over all given
-#'                                           \code{activity.types} is of interest (instead of one value per type).
-#'                                           [default: FALSE]
+#'                                   \code{activity.types} is of interest (instead of one value per type)
+#'                                   [default: FALSE]
 #'
-#' @return A list of networks with the added attribute.
+#' @return A list of networks with the added attribute
+#'
+#' @seealso add.vertex.attribute.author.aggregated.activity
 add.vertex.attribute.author.first.activity = function(list.of.networks, project.data,
-                                               activity.types = c("mails", "commits", "issues"),
-                                               name = "first.activity",
-                                               aggregation.level = c("range", "cumulative", "all.ranges",
-                                                                     "project.cumulative", "project.all.ranges",
-                                                                     "complete"),
-                                               default.value = NA,
-                                               combine.activity.types = FALSE) {
+                                                      activity.types = c("mails", "commits", "issues"),
+                                                      name = "first.activity",
+                                                      aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                            "project.cumulative", "project.all.ranges",
+                                                                            "complete"),
+                                                      default.value = NA,
+                                                      combine.activity.types = FALSE) {
+    return(add.vertex.attribute.author.aggregated.activity(list.of.networks, project.data, activity.types, name,
+                                                           aggregation.level, default.value, combine.activity.types,
+                                                           aggregation.function = min,
+                                                           data.aggregation.function = get.first.activity.data))
+}
+
+
+#' Add last activity attribute.
+#'
+#' @param list.of.networks The network list
+#' @param project.data The project data
+#' @param activity.types The kinds of activity to use as basis: One or more of \code{mails}, \code{commits} and
+#'                       \code{issues} [default: c("mails", "commits", "issues")]
+#' @param name The attribute name to add [default: "last.activity"]
+#' @param aggregation.level Determines the data to use for the attribute calculation.
+#'                          One of \code{"range"}, \code{"cumulative"}, \code{"all.ranges"},
+#'                          \code{"project.cumulative"}, \code{"project.all.ranges"}, and
+#'                          \code{"complete"}. See \code{split.data.by.networks} for
+#'                          more details. [default: "complete"]
+#' @param default.value The default value to add if a vertex has no matching value [default: NA]
+#' @param combine.all.activity.types Flag indicating that one value, computed over all given
+#'                                   \code{activity.types} is of interest (instead of one value per type)
+#'                                   [default: FALSE]
+#'
+#' @return A list of networks with the added attribute
+#'
+#' @seealso add.vertex.attribute.author.aggregated.activity
+add.vertex.attribute.author.last.activity = function(list.of.networks, project.data,
+                                                     activity.types = c("mails", "commits", "issues"),
+                                                     name = "last.activity",
+                                                     aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                           "project.cumulative", "project.all.ranges",
+                                                                           "complete"),
+                                                     default.value = NA,
+                                                     combine.activity.types = FALSE) {
+    return(add.vertex.attribute.author.aggregated.activity(list.of.networks, project.data, activity.types, name,
+                                                           aggregation.level, default.value, combine.activity.types,
+                                                           aggregation.function = max,
+                                                           data.aggregation.function = get.last.activity.data))
+}
+
+
+#' Add aggregated activity-date attribute.
+#'
+#' @param list.of.networks The network list
+#' @param project.data The project data
+#' @param activity.types The kinds of activity to use as basis: One or more of \code{mails}, \code{commits} and
+#'                       \code{issues} [default: c("mails", "commits", "issues")]
+#' @param name The attribute name to add [default: "aggregated.activity"]
+#' @param aggregation.level Determines the data to use for the attribute calculation.
+#'                          One of \code{"range"}, \code{"cumulative"}, \code{"all.ranges"},
+#'                          \code{"project.cumulative"}, \code{"project.all.ranges"}, and
+#'                          \code{"complete"}. See \code{split.data.by.networks} for
+#'                          more details [default: "complete"]
+#' @param default.value The default value to add if a vertex has no matching value [default: NA]
+#' @param combine.all.activity.types Flag indicating that one value, computed over all given
+#'                                   \code{activity.types} is of interest (instead of one value per type)
+#'                                   [default: FALSE]
+#' @param aggregation.function The function that should be used to aggregate when combining all activity types
+#' @param data.aggregation.function The function that should be used to aggregate the activity information per author
+#'                                  within activity types
+#'
+#' @return A list of networks with the added attribute
+add.vertex.attribute.author.aggregated.activity = function(list.of.networks, project.data,
+                                                           activity.types = c("mails", "commits", "issues"),
+                                                           name = "aggregated.activity",
+                                                           aggregation.level = c("range", "cumulative", "all.ranges",
+                                                                                 "project.cumulative", "project.all.ranges",
+                                                                                 "complete"),
+                                                           default.value = NA,
+                                                           combine.activity.types = FALSE,
+                                                           aggregation.function,
+                                                           data.aggregation.function) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "complete")
     parsed.activity.types = match.arg.or.default(activity.types, several.ok = TRUE)
 
@@ -730,17 +805,17 @@ add.vertex.attribute.author.first.activity = function(list.of.networks, project.
     }
 
     compute.attr = function(range, range.data, net) {
-        data = get.first.activity.data(range.data, parsed.activity.types, type.default)
+        data = data.aggregation.function(range.data, parsed.activity.types, type.default)
 
-        ## If configured, find minimum over all activity types per author, for example:
+        ## If configured, aggregate over all activity types per author. For example, for first activity
         ## data
         ##      list(authorA = list(mails = 1, commits = 2), authorB = list(mails = 3, commits = 3))
         ## yields
         ##      list(authorA = list(all.activities = 1), authorB = list(all.activities = 3))
         if (combine.activity.types) {
             data = parallel::mclapply(data, function(item.list) {
-                min.value = min(do.call(base::c, item.list), na.rm = TRUE)
-                return(list(all.activities = min.value))
+                aggregated.value = aggregation.function(do.call(base::c, item.list), na.rm = TRUE)
+                return(list(all.activities = aggregated.value))
             })
         }
         return(data)
@@ -760,7 +835,7 @@ add.vertex.attribute.author.first.activity = function(list.of.networks, project.
 #' @param project.data The project data
 #' @param name The attribute name to add [default: "active.ranges"]
 #' @param activity.types The kinds of activity to use as basis: One or more of \code{mails}, \code{commits} and
-#'                       \code{issues}. [default: c("mails", "commits", "issues")]
+#'                       \code{issues} [default: c("mails", "commits", "issues")]
 #' @param default.value The default value to add if a vertex has no matching value [default: list()]
 #' @param combine.activity.types Flag indicating that one value, computed over all given
 #'                                           \code{activity.types} is of interest (instead of one value per type).


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

While we already have functionality to compute the first activity per developer, there was no functionality yet to compute the last activity per developer. With this PR, functionality to compute the last activity per developer is added.

### Changelog

#### Added
- Add function to compute last activity per person and activity type
- Add function to add vertex attribute "last.activity"

