### PR TITLE
Replace deprecated function calls and parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,8 @@
 
 ### Announcement
 
-- Coronet is not compatible with `igraph` versions below 2.1.0 anymore. This is due to the simultaneous deprecation of `subgraph.edges` and the introduction of the replacement for it, `subgraph_from_edges`, in igraph version 2.1.0.
+- coronet is not compatible with `igraph` versions below 2.1.0 anymore. This is due to the simultaneous deprecation of `subgraph.edges` and the introduction of the replacement for it, `subgraph_from_edges`, in `igraph` version 2.1.0.
+- The plotting module of coronet is not compatible with `ggplot2` versions below 3.5.0 anymore. This is due to the simultaneous deprecation of the `scale_name` parameter of `discrete_scale`, which is used within the function `plot.network` of coronet.
 
 ### Added
 
@@ -26,11 +27,13 @@
 
 - **Breaking Change**: Change the default representation of edge attributes from vectors to lists. This change is necessary for the interplay of coronet networks with certain `igraph` functionality since igraph version 2.1.0 (PR #274, 1c35d1fa2548deb297dbfa5e2b07fce31962c5b7, eda30b838369ec46376812298a3ea8159eec5789, 0c6b2eba79b37f8ef2af7ffc41d86f1f307581bf, 44c7b72e3234cb332bb2713fb408c124e67255d9, 7303eabef6a78198575fe5bdfc02813fde3d3974, 0c27012641d24e19e5fa037406b480034c93f1aa)
 - Change the default value for the `issues.from.source` configuration parameter. Instead of reading JIRA and GitHub issues together, which was the previous default, the new default value causes only GitHub issue data to be read. To restore the previous default behavior and read data from both issue sources, this now needs to be manually configured when needed. (PR #264, 5ff83c364f6bfc1e6ff95e9c5f1087e031c48a5d, 8c8080cb9caf115f19d9f145ad6e6c108b131a67, 8bcbc81db521877908d2e5c2989082ed672f2a3b)
-- Replace deprecated `igraph` functions by their preferred alternatives (PR #264, PR #268, PR #274, 0df9d5bf6bafbb5d440f4c47db4ec901cf11f037, 7ac840d287a862eff61b1a84e194a4cba399f9e5, e3617b8c6b21fb4242c1d392124813501069ca84, 4b0d5221dd56bb3c9ddf196f67719d4f503d9b61)
+- Replace deprecated `igraph` functions by their preferred alternatives (PR #264, PR #268, PR #274, PR #279, 0df9d5bf6bafbb5d440f4c47db4ec901cf11f037, 7ac840d287a862eff61b1a84e194a4cba399f9e5, e3617b8c6b21fb4242c1d392124813501069ca84, 4b0d5221dd56bb3c9ddf196f67719d4f503d9b61, f29662b2c11768cc01eb0f86d32e039099c618ae)
+- Remove deprecated parameter of `ggplot2::discrete_scale` (PR #279, 027ce79cdc85a81a5b386bf925f3545632426433)
 - Deprecate support for R version 3.6 (PR #264, c8e6f45111e487fadbe7f0a13c7595eb23f3af6e, fb3f5474259d4a88f4ff545691cca9d1ccde90e3)
 - Explicitly add R version 4.4 to the CI test pipeline (c8e6f45111e487fadbe7f0a13c7595eb23f3af6e)
 - Refactor function `construct.edge.list.from.key.value.list` to be more readable (PR #263, 05c3bc09cb1d396fd59c34a88030cdca58fd04dd)
 - Update necessary `igraph` version to 2.1.0 in `README.md` (PR #274, 6c3bcd1a2366d0d3a176d9fde95b8356b0158da3)
+- Update necessary `ggplot2` version to 3.5.0 in `README.md' (PR #279, 027ce79cdc85a81a5b386bf925f3545632426433)
 - Include core/peripheral classification in the `README.md` (PR #276, 6101e11f5c4ac1b5883e85cebd01a3cd7c76e056, c6744c00d3dc0d4e45a96c2d80ae78727e22cce2, 5fc2da5ece6604a6a87d8dd5f79237a82fb2b5ca)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -137,14 +137,14 @@ Alternatively, you can run `Rscript install.R` to install the packages.
 - `reshape2`: For reshaping of data
 - `testthat`: For the test suite
 - `patrick`: For the test suite
-- `ggplot2`: For plotting of data
+- `ggplot2`: For plotting of data (package version `3.5.0` or higher is required)
 - `ggraph`: For plotting of networks (needs `udunits2` system library, e.g., `libudunits2-dev` on Ubuntu!)
 - `markovchain`: For core/peripheral transition probabilities
 - `lubridate`: For convenient date conversion and parsing
 - `viridis`: For plotting of networks with nice colors
 - `jsonlite`: For parsing the issue data
 - `rTensor`: For calculating EDCPTD centrality
-- `Matrix`: For sparse matrix representation of large adjacency matrices (package version `1.3.0` or higher is mandatory)
+- `Matrix`: For sparse matrix representation of large adjacency matrices (package version `1.3.0` or higher is required)
 - `fastmap`: For fast implementation of a map
 - `purrr`: For fast implementation of a mapping function
 

--- a/util-networks-metrics.R
+++ b/util-networks-metrics.R
@@ -12,7 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2015, 2019 by Thomas Bock <bockthom@fim.uni-passau.de>
-## Copyright 2021, 2023-2024 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2021, 2023-2025 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2017 by Raphael Nömmer <noemmer@fim.uni-passau.de>
 ## Copyright 2017-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017-2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
@@ -94,7 +94,7 @@ metrics.vertex.degrees = function(network, sort = TRUE, sort.decreasing = TRUE, 
 #'
 #' @return The density of the network.
 metrics.density = function(network) {
-    density = igraph::graph.density(network)
+    density = igraph::edge_density(network)
     return(c(density = density))
 }
 
@@ -110,7 +110,7 @@ metrics.density = function(network) {
 #'
 #' @return The average path length of the given network.
 metrics.avg.pathlength = function(network, directed = TRUE, unconnected = TRUE) {
-    avg.pathlength = igraph::average.path.length(network, directed = directed, unconnected = unconnected)
+    avg.pathlength = igraph::mean_distance(network, directed = directed, unconnected = unconnected)
     return(c(avg.pathlength = avg.pathlength))
 }
 
@@ -164,7 +164,7 @@ metrics.modularity = function(network, community.detection.algorithm = igraph::c
 #' @return The smallworldness value of the network.
 metrics.smallworldness = function(network) {
     ## first check whether the network is simplified
-    if (!is.simple(network)) {
+    if (!is_simple(network)) {
         ## if this is not the case, raise an error and stop the execution
         error.message = "The input network has too many edges. Try again with a simplified network."
         logging::logerror(error.message)
@@ -173,17 +173,16 @@ metrics.smallworldness = function(network) {
 
     ## else construct Erdös-Renyi network 'h' with same number of vertices and edges as the given network 'network',
     ## as the requirement of the function is fulfilled
-    h = igraph::erdos.renyi.game(n = igraph::vcount(network),
-                                 p.or.m = igraph::ecount(network),
-                                 type = "gnm",
-                                 directed = FALSE)
+    h = igraph::sample_gnm(n = igraph::vcount(network),
+                           m = igraph::ecount(network),
+                           directed = FALSE)
 
     ## compute clustering coefficients
     g.cc = igraph::transitivity(network, type = "global")
     h.cc = igraph::transitivity(h, type = "global")
     ## compute average shortest-path length
-    g.l = igraph::average.path.length(network, unconnected = TRUE)
-    h.l = igraph::average.path.length(h, unconnected = TRUE)
+    g.l = igraph::mean_distance(network, unconnected = TRUE)
+    h.l = igraph::mean_distance(h, unconnected = TRUE)
 
     ## binary decision
     ## intermediate variables

--- a/util-plot.R
+++ b/util-plot.R
@@ -14,7 +14,7 @@
 ## Copyright 2017-2018, 2020 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2018 by Barbara Eckl <ecklbarb@fim.uni-passau.de>
 ## Copyright 2018 by Thomas Bock <bockthom@fim.uni-passau.de>
-## Copyright 2020-2021 by Thomas Bock <bockthom@cs.uni-saarland.de>
+## Copyright 2020-2021, 2025 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2024 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
 ## All Rights Reserved.
 
@@ -168,8 +168,8 @@ plot.get.plot.for.network = function(network, labels = TRUE) {
 
         ## scale edges (colors and styles)
         ggraph::scale_edge_linetype(name = "Relation Types") +
-        ggplot2::discrete_scale(name = "Relations", "edge_colour", "viridis",
-                                viridis::viridis_pal(option = "viridis", end = 0.8, begin = 0.25)) +
+        ggplot2::discrete_scale(name = "Relations", aesthetics = "edge_colour",
+                                palette = viridis::viridis_pal(option = "viridis", end = 0.8, begin = 0.25)) +
         ## BROKEN RIGHT NOW due to bug in scale_edge_colour_viridis():
         # ggraph::scale_edge_colour_viridis(name = "Relations", option = "magma", discrete = TRUE,
         #                                   end = 0.85, begin = 0, direction = 1) +


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

Replace deprecated igraph functions in 'util-networks-metrics.R' and remove deprecated `scale_name` parameter from plotting module. This works towards #260.

### Changelog

- Replace deprecated igraph functions in 'util-networks-metrics.R': 
    - `erdos.renyi.game` of type "gnm" has been replaced by `sample_gnm`
    - `average.path.length` has been replaced by `mean_distance`
    - `graph.density` has been replaced by `edge_density`
    - `is.simple` has been replaced by `is_simple`
- As of `ggplot2` version 3.5.0, the function `discrete_scale`, which is used for `plot.network` in coronet, does not require a `scale_name` parameter anymore. Even more, this parameter has been deprecated. Therefore, we also don't use it any more in coronet. However, as a consequence of this, the plotting module of coronet requires `ggplot2` version 3.5.0 or higher, as of now.