### PR TITLE
Miscellaneous fixes and improvements in network construction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,12 +14,19 @@
 
 - For consistency reasons: Ensure that the values of edge attributes are always lists even when they represent singular values (PR #278, 6fae1843740ed8e48c89c2ee4e61f995b5d0b8f5, 416c817998540fc0b82d9959574838b571b4d6fb)
 - Reduce the amount of redundantly built networks by caching network data internally. This should improve the performance of building multi-networks, especially, when parts of the multi-networks have been built before (#119, PR #282, 06a814c945f0b20af842d20247126083523cde55, 4793eab02e8792b0640fad88a90018292b1b2ab9, 8ba907fff0534c6fef39bd289ab163c90b053530, 28d22902e32e93c0d4990576da2ef3de88fdffbd, 3608214b9bcf1ac5edc0c47182993c4fcc95d8b0, b30c7f2b5b0a6d12e8024fafada5490170530ebe, 1fa340d6347090a327b4c32ece705c1f700234e5, 40cd55423be7b6521e2fc35f5aa200ff0594e77c, 8fcc74439c28b1592e964dd753bfc1cd57c062be, ca348f1de8e3b4e5786a6d2726ca14e530446896, 1d233af734f79e677d3388f7c3589ce186cc3a8d, 5dd5fc18940ce9ac9598902f175193167b471966)
-- Internally cache commit-network data similarly to how we cache network data for author-, and artifact-networks (PR #282, 3608214b9bcf1ac5edc0c47182993c4fcc95d8b0)
+- Internally cache commit-network data and bipartite-network data similarly to how we cache network data for author-, and artifact-networks (PR #282, PR #285, 3608214b9bcf1ac5edc0c47182993c4fcc95d8b0, aa7e3fae9f45df73054f7d9c6a96177575106c7d)
 - Remove redundant entries from the list of allowed edge attributes and instead add `event.info.1` and `event.info.2` (PR #282, 1b156c17f261d8b70d8d48c6cb94d3ee591559f3)
 - Ensure that configured or implicitly-enforced undirectedness in partial networks is always dominant over configured or implicitly-enforced directedness. Furthermore, ensure consistency in the directedness used for edge generation and as a network attribute, especially in networks that consist of multiple partial networks such as multi-networks (PR #282, 65ead39b7b971e5a0acbaee4e787efcf194aafc4, a776caf72256200e1bfa5578106a9b53547b00e7, 257a1c8a6a9b1c3e2a72960cc4051a87950753ee, 41cff01cf141a377c96048f0645e05fb200138e9)
 - Allow the issue data attributes `event.info.1` and `event.info.2` on network edges (PR #282, 1b156c17f261d8b70d8d48c6cb94d3ee591559f3)
+- Add a `network.type` parameter to `get.networks` in which the caller can specify the types of networks to be constructed. This improves performance in cases where not all network types are needed, such as when building multi-networks (PR #285, bc2efd643d92da547d4677f9026540c25e730a03, e9a0c1681a0b63bd831fe7657ce25a9d50dc6e83)
+- Rename the `list.attributes` parameter in `add.vertex.attribute` and `split.and.add.vertex.attribute` to `flatten.values` with inverted semantics and introduce documentation for it to improve comprehensibility (PR #285, 7dab04a5251d89c9cb286452528ef8b6775a7347)
 
 ### Fixed
+
+- Fix a bug in `construct.edge.list.from.key.value.list` that could cause a crash when constructing a network where different vertices have identical associated timestamps (PR #285, d694a6847c36d32dfee60f7d5b082e1d3ba57e01)
+- Fix a bug in network construction that could lead to edges having an unwanted `author.name.1` attribute (PR #285, 105fec1acc436378a9282c40fcae0eb0257f00be)
+- Ensure that POSIXct values are correctly handled in `add.vertex.attribute`, i.e., that they are not converted to numeric values (PR #285, 7dab04a5251d89c9cb286452528ef8b6775a7347, 4924ac23737dec6f915edaeb350a5cbaebbeec79)
+- Handle empty edges when constructing commit networks using commit-interaction data (PR #285, d5e1e4801230224e6272cd66873bd43bb7f04a00)
 
 ## 5.0
 

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -22,7 +22,7 @@
 ## Copyright 2021 by Johannes Hostert <s8johost@stud.uni-saarland.de>
 ## Copyright 2021-2022 by Niklas Schneider <s8nlschn@stud.uni-saarland.de>
 ## Copyright 2022 by Jonathan Baumann <joba00002@stud.uni-saarland.de>
-## Copyright 2023-2024 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
+## Copyright 2023-2025 by Maximilian Löffler <s8maloef@stud.uni-saarland.de>
 ## All Rights Reserved.
 
 
@@ -1679,10 +1679,6 @@ test_that("Test add.vertex.attribute.artifact.first.occurrence", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "first.occurrence")
-
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_equal(expected.attributes[[level]], actual.attributes)
     })
 })
@@ -1737,10 +1733,6 @@ test_that("Test add.vertex.attribute.artifact.last.edited", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "last.edited")
-
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_equal(expected.attributes[[level]], actual.attributes)
     })
 })
@@ -1911,10 +1903,6 @@ test_that("Test add.vertex.attribute.mail.thread.start.date", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "thread.start.date")
-
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_equal(expected.attributes[[level]], actual.attributes)
     })
 })
@@ -1963,10 +1951,6 @@ test_that("Test add.vertex.attribute.mail.thread.end.date", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "thread.end.date")
-
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_equal(expected.attributes[[level]], actual.attributes)
     })
 })
@@ -2410,9 +2394,6 @@ test_that("Test add.vertex.attribute.issue.opened.date", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "issue.opened.date")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.issues.only, actual.attributes)
     })
 
@@ -2424,9 +2405,6 @@ test_that("Test add.vertex.attribute.issue.opened.date", {
             type = "pull.requests")
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "pr.opened.date")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.prs.only, actual.attributes)
     })
 
@@ -2438,9 +2416,6 @@ test_that("Test add.vertex.attribute.issue.opened.date", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "issue.opened.date")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.both, actual.attributes)
     })
 })
@@ -2510,9 +2485,6 @@ test_that("Test add.vertex.attribute.issue.closed.date", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "issue.closed.date")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.issues.only, actual.attributes)
     })
 
@@ -2524,9 +2496,6 @@ test_that("Test add.vertex.attribute.issue.closed.date", {
             type = "pull.requests")
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "pr.closed.date")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.prs.only, actual.attributes)
     })
 
@@ -2538,9 +2507,6 @@ test_that("Test add.vertex.attribute.issue.closed.date", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "issue.closed.date")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.both, actual.attributes)
     })
 })
@@ -2653,9 +2619,6 @@ test_that("Test add.vertex.attribute.issue.last.activity.date", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "issue.last.activity")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.issues.only[[level]], actual.attributes)
     })
 
@@ -2667,9 +2630,6 @@ test_that("Test add.vertex.attribute.issue.last.activity.date", {
             type = "pull.requests")
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "pr.last.activity")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.prs.only[[level]], actual.attributes)
     })
 
@@ -2681,9 +2641,6 @@ test_that("Test add.vertex.attribute.issue.last.activity.date", {
         )
 
         actual.attributes = lapply(networks.with.attr, igraph::vertex_attr, name = "issue.last.activity")
-        ## convert UNIX timestamps to POSIXct
-        actual.attributes = lapply(actual.attributes, get.date.from.unix.timestamp)
-
         expect_identical(expected.attributes.both[[level]], actual.attributes)
     })
 })

--- a/util-networks.R
+++ b/util-networks.R
@@ -797,7 +797,9 @@ NetworkBuilder = R6::R6Class("NetworkBuilder",
             artifact.index = match("artifact", edge.attributes, nomatch = NA)
             if (!is.na(artifact.index)) {
                 edge.attributes = edge.attributes[-artifact.index]
-                edge.attributes = c(edge.attributes, c("author.name"))
+                if (!("author.name" %in% edge.attributes)) {
+                    edge.attributes = c(edge.attributes, c("author.name"))
+                }
             }
 
             ## connect corresponding add_link and referenced_by issue-events
@@ -1547,7 +1549,9 @@ construct.edge.list.from.key.value.list = function(list, network.conf, directed 
         artifact.index = match("artifact", edge.attributes, nomatch = NA)
         if (!is.na(artifact.index)) {
             edge.attributes = edge.attributes[-artifact.index]
-            edge.attributes = c(edge.attributes, c("author.name"))
+            if (!("author.name" %in% edge.attributes)) {
+                edge.attributes = c(edge.attributes, c("author.name"))
+            }
         }
     }
 

--- a/util-networks.R
+++ b/util-networks.R
@@ -858,11 +858,13 @@ NetworkBuilder = R6::R6Class("NetworkBuilder",
             ## set the commits as the 'to' and 'from' of the network and order the dataframe
             edges = edges[, c("base.hash", "commit.hash", "func", "interacting.author",
                               "file", "base.author", "base.func", "base.file")]
-            if (nrow(edges) > 0) {
-                edges[["artifact.type"]] = ARTIFACT.COMMIT.INTERACTION
+            if (!is.null(edges)) {
+                if (nrow(edges) > 0) {
+                    edges[["artifact.type"]] = ARTIFACT.COMMIT.INTERACTION
+                }
+                colnames(edges)[1] = "to"
+                colnames(edges)[2] = "from"
             }
-            colnames(edges)[1] = "to"
-            colnames(edges)[2] = "from"
 
             ## construct network data
             network.data = private$construct.network.data(


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](../CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](../NEWS.md) appropriately.
- [x] I have checked whether I need to adjust the showcase file `showcase.R` with respect to my changes.
- [x] The pull request is opened against the branch `dev`.

### Description

<!-- Add a description of the added/changed/fixed functionality in this pull request. -->
Fix miscellaneous minor problems all around coronet:

- Fix a bug in `construct.edge.list.from.key.value.list` that can lead to a crash when building networks. The bug was triggered when two different vertices have the same assigned date.
- Fix a bug in `construct.edge.list.from.key.value.list` and `get.artifact.network.issue` in which the `author.name` attribute could be added again to edges that already had the `author.name` attribute leading to the creation of a redundant `author.name.1` attribute.
-  Add a parameter to `get.networks` to specify which networks to construct to improve performance in use-cases where not all networks are necessary (i.e., when building a multi-network).
- Adjust the flattening of list attributes values in `add.vertex.attribute`. Previously, a problem could lead to `POSIXct` attributes being converted in `numeric`. In addition, add documentation for an undocumented parameter to `add.vertex.attribute` and `split.and.add.vertex.attribute`.

### Changelog

<!-- Put the updated/added parts of the changelog here. -->
see above (for now)
